### PR TITLE
feat: Support Live Photo upload (paired HEIC + MOV)

### DIFF
--- a/proto/photon/imessage/v1/attachment_service.proto
+++ b/proto/photon/imessage/v1/attachment_service.proto
@@ -40,6 +40,10 @@ message UploadRequest {
   string file_name = 1;
   string mime_type = 2;
   bytes data = 3;
+  // Optional Live Photo companion video (.mov).
+  // When present the server writes a sibling .mov file next to the image,
+  // enabling getLivePhoto() to find it via the existing naming convention.
+  optional bytes live_photo_video = 4;
 }
 
 message UploadResponse {

--- a/src/generated/photon/imessage/v1/attachment_service.ts
+++ b/src/generated/photon/imessage/v1/attachment_service.ts
@@ -30,6 +30,12 @@ export interface UploadRequest {
   fileName: string;
   mimeType: string;
   data: Uint8Array;
+  /**
+   * Optional Live Photo companion video (.mov).
+   * When present the server writes a sibling .mov file next to the image,
+   * enabling getLivePhoto() to find it via the existing naming convention.
+   */
+  livePhotoVideo?: Uint8Array | undefined;
 }
 
 export interface UploadResponse {
@@ -286,7 +292,7 @@ export const GetAttachmentCountResponse: MessageFns<GetAttachmentCountResponse> 
 };
 
 function createBaseUploadRequest(): UploadRequest {
-  return { fileName: "", mimeType: "", data: new Uint8Array(0) };
+  return { fileName: "", mimeType: "", data: new Uint8Array(0), livePhotoVideo: undefined };
 }
 
 export const UploadRequest: MessageFns<UploadRequest> = {
@@ -299,6 +305,9 @@ export const UploadRequest: MessageFns<UploadRequest> = {
     }
     if (message.data.length !== 0) {
       writer.uint32(26).bytes(message.data);
+    }
+    if (message.livePhotoVideo !== undefined) {
+      writer.uint32(34).bytes(message.livePhotoVideo);
     }
     return writer;
   },
@@ -334,6 +343,14 @@ export const UploadRequest: MessageFns<UploadRequest> = {
           message.data = reader.bytes();
           continue;
         }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.livePhotoVideo = reader.bytes();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -356,6 +373,11 @@ export const UploadRequest: MessageFns<UploadRequest> = {
         ? globalThis.String(object.mime_type)
         : "",
       data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0),
+      livePhotoVideo: isSet(object.livePhotoVideo)
+        ? bytesFromBase64(object.livePhotoVideo)
+        : isSet(object.live_photo_video)
+        ? bytesFromBase64(object.live_photo_video)
+        : undefined,
     };
   },
 
@@ -370,6 +392,9 @@ export const UploadRequest: MessageFns<UploadRequest> = {
     if (message.data.length !== 0) {
       obj.data = base64FromBytes(message.data);
     }
+    if (message.livePhotoVideo !== undefined) {
+      obj.livePhotoVideo = base64FromBytes(message.livePhotoVideo);
+    }
     return obj;
   },
 
@@ -381,6 +406,7 @@ export const UploadRequest: MessageFns<UploadRequest> = {
     message.fileName = object.fileName ?? "";
     message.mimeType = object.mimeType ?? "";
     message.data = object.data ?? new Uint8Array(0);
+    message.livePhotoVideo = object.livePhotoVideo ?? undefined;
     return message;
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type { AddressInfo } from "./types/addresses.js";
 export type {
   AttachmentInfo,
   AttachmentInput,
+  LivePhotoInput,
   StreamedDownload,
 } from "./types/attachments.js";
 // Branded types + constructors

--- a/src/resources/attachments.ts
+++ b/src/resources/attachments.ts
@@ -10,6 +10,7 @@ import { mapAttachmentInfo } from "../transport/mapper.ts";
 import type {
   AttachmentInfo,
   AttachmentInput,
+  LivePhotoInput,
   StreamedDownload,
 } from "../types/attachments.ts";
 import type { AttachmentGuid } from "../types/branded.ts";
@@ -164,6 +165,28 @@ export class AttachmentsResource {
   // -------------------------------------------------------------------------
   // Upload
   // -------------------------------------------------------------------------
+
+  /**
+   * Upload a Live Photo (paired image + video) in a single atomic request.
+   *
+   * The server writes the video as a `.mov` companion file next to the
+   * image, so `getLivePhoto()` and `hasLivePhoto` work automatically.
+   * Returns the image attachment with `hasLivePhoto: true`.
+   */
+  async uploadLivePhoto(input: LivePhotoInput): Promise<AttachmentInfo> {
+    try {
+      const response = await this._client.upload({
+        fileName: input.image.fileName,
+        mimeType: input.image.mimeType,
+        data: input.image.data,
+        livePhotoVideo: input.video.data,
+      });
+
+      return mapAttachmentInfo(unwrap(response.attachment, "attachment"));
+    } catch (err) {
+      throw fromGrpcError(err);
+    }
+  }
 
   /**
    * Upload an attachment to the server.

--- a/src/types/attachments.ts
+++ b/src/types/attachments.ts
@@ -76,6 +76,40 @@ export type AttachmentInput =
     };
 
 // ---------------------------------------------------------------------------
+// LivePhotoInput
+// ---------------------------------------------------------------------------
+
+/**
+ * Input for uploading a Live Photo (paired image + video).
+ *
+ * Supply raw bytes for both components. The server writes the video as a
+ * companion `.mov` sibling file, matching the convention used by
+ * `getLivePhoto()` for download. The video file name and MIME type are
+ * determined server-side (always `.mov` / `video/quicktime`).
+ *
+ * @example
+ * ```ts
+ * const att = await im.attachments.uploadLivePhoto({
+ *   image: { data: heicBytes, fileName: "photo.HEIC", mimeType: "image/heic" },
+ *   video: { data: movBytes },
+ * });
+ * console.log(att.hasLivePhoto); // true
+ * ```
+ */
+export interface LivePhotoInput {
+  /** The still-image component (typically HEIC or JPEG). */
+  readonly image: {
+    readonly data: Uint8Array;
+    readonly fileName: string;
+    readonly mimeType: string;
+  };
+  /** The companion video component (raw `.mov` bytes). */
+  readonly video: {
+    readonly data: Uint8Array;
+  };
+}
+
+// ---------------------------------------------------------------------------
 // StreamedDownload
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
  - Add `optional bytes live_photo_video` field to `UploadRequest` proto
  - Add `LivePhotoInput` type and `uploadLivePhoto()` method to `AttachmentsResource`
  - Video component only requires raw bytes — fileName/mimeType determined server-side

  ## Test plan
  - [ ] `uploadLivePhoto()` returns `hasLivePhoto: true`
  - [ ] `getAttachment()` metadata persists `hasLivePhoto: true`
  - [ ] `downloadBuffer()` returns exact original HEIC bytes
  - [ ] `getLivePhoto()` returns exact original MOV bytes
  - [ ] Regular `upload()` returns `hasLivePhoto: false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading Live Photos alongside standard image attachments, enabling users to share the interactive photo format with paired video content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->