### PR TITLE
feat: set TLS default to true

### DIFF
--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -87,6 +87,7 @@ export interface GrpcClientOptions {
   autoIdempotency?: boolean;
   /**
    * Whether to use TLS. If `true`, the channel uses SSL credentials.
+   * If `false`, this forces `ChannelCredentials.createInsecure()`.
    * Defaults to `true`.
    */
   tls?: boolean;

--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -87,7 +87,7 @@ export interface GrpcClientOptions {
   autoIdempotency?: boolean;
   /**
    * Whether to use TLS. If `true`, the channel uses SSL credentials.
-   * Defaults to `false` (insecure).
+   * Defaults to `true`.
    */
   tls?: boolean;
   /**
@@ -117,9 +117,10 @@ export interface GrpcClientOptions {
  */
 export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
   // --- Channel ---
-  const credentials = options.tls
-    ? ChannelCredentials.createSsl()
-    : ChannelCredentials.createInsecure();
+  const credentials =
+    (options.tls ?? true)
+      ? ChannelCredentials.createSsl()
+      : ChannelCredentials.createInsecure();
 
   const channel = createChannel(options.address, credentials);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changes the default value of the `tls` option from `false` to `true` in `GrpcClientOptions`.

## Changes

- **`src/transport/grpc-client.ts`**: Updated `createGrpcClients` to use `options.tls ?? true` instead of a bare `options.tls` check, so omitting the option now defaults to SSL credentials instead of insecure.
- Updated the JSDoc on `GrpcClientOptions.tls` to document the new default (`true`).

## Breaking Change

Users who previously relied on the implicit `tls: false` default for insecure connections must now explicitly pass `tls: false`.

Resolves ENG-1076
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-1076](https://linear.app/photonhq/issue/ENG-1076/set-tls-default-to-true)

<div><a href="https://cursor.com/agents/bc-542760ca-8f08-492b-b23f-aba7c62b3212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-542760ca-8f08-492b-b23f-aba7c62b3212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration & Documentation**
  * TLS/SSL is now enabled by default for gRPC client connections. Documentation and option descriptions have been updated to reflect the new default. Users can still disable TLS by explicitly setting the option to false.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->