### PR TITLE
fix: Pass autoIdempotency option through to gRPC client factory

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -41,6 +41,7 @@ export interface AdvancedIMessage extends AsyncDisposable {
 export function createClient(options: ClientOptions): AdvancedIMessage {
   const clients = createGrpcClients({
     address: options.address,
+    autoIdempotency: options.autoIdempotency,
     tls: options.tls,
     token: options.token,
   });


### PR DESCRIPTION
## Summary
  - `createClient` now forwards `autoIdempotency` to `createGrpcClients`, enabling the idempotency middleware that was already fully implemented but unreachable

  ## Context
  `ClientOptions.autoIdempotency` was declared in the public API and the entire downstream chain existed (`GrpcClientOptions` → `idempotencyMiddleware` → `x-idempotency-key` header → server `AuthInterceptor` → `SendPolicyOrchestrator` dedup), but `createClient` omitted it from the `createGrpcClients({...})` call.
  Users setting `autoIdempotency: true` had no effect.

  ## Test plan
  - [ ] Verify `x-idempotency-key` header is present on mutating RPCs when `autoIdempotency: true`
  - [ ] Verify header is absent on read RPCs (Get*, List*, Check*, Subscribe*)
  - [ ] Verify header is absent when `autoIdempotency` is unset or `false`
  - [ ] Confirm server dedup rejects duplicate keys with `duplicateMessage` error
  
  Fix ENG-1134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `autoIdempotency` configuration option was not being properly applied when creating a client instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->