### PR TITLE
fix: retry and timeout options not being used by the SDK

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,9 +1,19 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "extends": [
-    "ultracite/biome/core"
-  ],
+  "extends": ["ultracite/biome/core"],
   "files": {
     "includes": ["!!bun.lock"]
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["tests/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "useAwait": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,6 +42,8 @@ export function createClient(options: ClientOptions): AdvancedIMessage {
   const clients = createGrpcClients({
     address: options.address,
     autoIdempotency: options.autoIdempotency,
+    retry: options.retry,
+    timeout: options.timeout,
     tls: options.tls,
     token: options.token,
   });

--- a/src/errors/error-handler.ts
+++ b/src/errors/error-handler.ts
@@ -22,6 +22,7 @@
 
 import { ClientError, Status } from "nice-grpc-common";
 import type { ErrorCode } from "../types/errors.ts";
+import { readMetadataValue } from "../utils/grpc-metadata.ts";
 import {
   AuthenticationError,
   ConnectionError,
@@ -31,37 +32,6 @@ import {
   RateLimitError,
   ValidationError,
 } from "./imessage-error.ts";
-
-// ---------------------------------------------------------------------------
-// Metadata helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Attempt to read a string value from gRPC trailing metadata.
- *
- * nice-grpc-common's `ClientError` does not expose metadata directly, so we
- * also accept a raw `@grpc/grpc-js` status object (which carries a `metadata`
- * field with a `.get()` method).
- */
-function readMetadataValue(error: unknown, key: string): string | undefined {
-  // The raw @grpc/grpc-js error carries `metadata` with a `.get()` method
-  // that returns an array of MetadataValue (string | Buffer).
-  const meta = (error as { metadata?: { get(key: string): unknown[] } })
-    .metadata;
-
-  if (!meta || typeof meta.get !== "function") {
-    return undefined;
-  }
-
-  const values = meta.get(key);
-
-  if (!Array.isArray(values) || values.length === 0) {
-    return undefined;
-  }
-
-  const first = values[0];
-  return typeof first === "string" ? first : undefined;
-}
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -31,8 +31,15 @@ import { PollServiceDefinition } from "../generated/photon/imessage/v1/poll_serv
 import type { ScheduledMessageServiceClient } from "../generated/photon/imessage/v1/scheduled_message_service.ts";
 import { ScheduledMessageServiceDefinition } from "../generated/photon/imessage/v1/scheduled_message_service.ts";
 
+import type { RetryOptions } from "../types/common.ts";
 // Middleware
-import { authMiddleware, idempotencyMiddleware } from "./metadata.ts";
+import {
+  authMiddleware,
+  idempotencyMiddleware,
+  retryMiddleware,
+  timeoutMiddleware,
+  trailingMetadataCaptureMiddleware,
+} from "./metadata.ts";
 
 // ---------------------------------------------------------------------------
 // Client type aliases
@@ -86,6 +93,17 @@ export interface GrpcClientOptions {
    */
   autoIdempotency?: boolean;
   /**
+   * Enable automatic retry with exponential backoff for retryable errors.
+   * Pass `true` for default settings, or a `RetryOptions` object to
+   * customise the behaviour.
+   */
+  retry?: boolean | RetryOptions;
+  /**
+   * Default timeout in milliseconds for unary RPC calls.
+   * Sets a deadline on each call unless one is already provided.
+   */
+  timeout?: number;
+  /**
    * Whether to use TLS. If `true`, the channel uses SSL credentials.
    * Defaults to `false` (insecure).
    */
@@ -124,17 +142,32 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
   const channel = createChannel(options.address, credentials);
 
   // --- Client factory with middleware ---
+  //
+  // Middleware is added outermost-first: the first .use() call runs first
+  // in the call chain. Desired execution order:
+  //   idempotency → retry → timeout → auth → trailingMetadataCapture → RPC
   let factory = createClientFactory();
 
-  // Idempotency middleware runs first (outermost), so it executes before auth.
   if (options.autoIdempotency) {
     factory = factory.use(idempotencyMiddleware());
   }
 
-  // Auth middleware runs after idempotency (innermost), closest to the wire.
+  if (options.retry) {
+    const retryOpts = options.retry === true ? {} : options.retry;
+    factory = factory.use(retryMiddleware(retryOpts));
+  }
+
+  if (options.timeout) {
+    factory = factory.use(timeoutMiddleware(options.timeout));
+  }
+
   if (options.token) {
     factory = factory.use(authMiddleware(options.token));
   }
+
+  // Always capture trailing metadata — nice-grpc strips it from errors,
+  // but our error handler and retry middleware depend on it.
+  factory = factory.use(trailingMetadataCaptureMiddleware());
 
   // --- Create clients ---
   // ts-proto definitions are natively compatible with nice-grpc, no casts needed.

--- a/src/transport/metadata.ts
+++ b/src/transport/metadata.ts
@@ -10,6 +10,7 @@ import {
   type ClientMiddleware,
   Metadata,
 } from "nice-grpc-common";
+import type { RetryOptions } from "../types/common.ts";
 import { generateIdempotencyKey } from "../utils/idempotency.ts";
 
 // ---------------------------------------------------------------------------
@@ -86,5 +87,166 @@ export function idempotencyMiddleware(): ClientMiddleware {
     };
 
     return yield* call.next(call.request, nextOptions);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retry middleware
+// ---------------------------------------------------------------------------
+
+/** Default retry settings (4 total attempts with exponential backoff). */
+const DEFAULT_MAX_ATTEMPTS = 4;
+const DEFAULT_INITIAL_DELAY = 200;
+const DEFAULT_MAX_DELAY = 5000;
+
+/**
+ * Read a string value from gRPC trailing metadata attached to an error.
+ */
+function readMetadataValue(error: unknown, key: string): string | undefined {
+  const meta = (error as { metadata?: { get(key: string): unknown[] } })
+    .metadata;
+  if (!meta || typeof meta.get !== "function") {
+    return undefined;
+  }
+  const values = meta.get(key);
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+  const first = values[0];
+  return typeof first === "string" ? first : undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Creates a nice-grpc client middleware that automatically retries failed
+ * unary calls when the server indicates the error is retryable (via the
+ * `x-retryable` trailing metadata header).
+ *
+ * Uses exponential backoff with full jitter.  Streaming calls are passed
+ * through without retry.
+ */
+export function retryMiddleware(opts: RetryOptions = {}): ClientMiddleware {
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const initialDelay = opts.initialDelay ?? DEFAULT_INITIAL_DELAY;
+  const maxDelay = opts.maxDelay ?? DEFAULT_MAX_DELAY;
+
+  return async function* retryMw(call, options) {
+    // Skip streaming calls — retrying mid-stream would duplicate data.
+    if (call.method.responseStream || call.method.requestStream) {
+      return yield* call.next(call.request, options);
+    }
+
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        return yield* call.next(call.request, options);
+      } catch (error: unknown) {
+        lastError = error;
+
+        const retryable = readMetadataValue(error, "x-retryable") === "true";
+
+        if (!retryable || attempt >= maxAttempts - 1) {
+          throw error;
+        }
+
+        // Exponential backoff with full jitter.
+        const exponentialDelay = initialDelay * 2 ** attempt;
+        const cappedDelay = Math.min(exponentialDelay, maxDelay);
+        await sleep(Math.random() * cappedDelay);
+      }
+    }
+
+    throw lastError;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timeout middleware
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Trailing metadata capture middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * nice-grpc wraps `@grpc/grpc-js` errors into `ClientError`, **dropping
+ * trailing metadata** in the process (see `wrapClientError.ts`).  This
+ * middleware intercepts the `onTrailer` callback to capture trailing metadata
+ * and re-attaches it to errors in a format compatible with `readMetadataValue`.
+ *
+ * It should always be the **innermost** middleware so that outer middleware
+ * (retry, error handlers) can read server-sent headers like `error-code`
+ * and `x-retryable`.
+ */
+export function trailingMetadataCaptureMiddleware(): ClientMiddleware {
+  return async function* trailingMetadataCaptureMw(call, options) {
+    let trailer: ReturnType<typeof Metadata> | undefined;
+
+    try {
+      return yield* call.next(call.request, {
+        ...options,
+        onTrailer(t) {
+          trailer = t;
+          options.onTrailer?.(t);
+        },
+      });
+    } catch (error) {
+      // Yield one microtask so that the onTrailer handler has a chance
+      // to fire in case @grpc/grpc-js delivers it via nextTick.
+      await Promise.resolve();
+
+      if (trailer && error instanceof Error) {
+        // Attach an adapter matching the shape readMetadataValue expects:
+        // { get(key): unknown[] }
+        const captured = trailer;
+        Object.defineProperty(error, "metadata", {
+          value: {
+            get(key: string): unknown[] {
+              const val = captured.get(key);
+              return val === undefined ? [] : [val];
+            },
+          },
+          writable: true,
+          configurable: true,
+        });
+      }
+      throw error;
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timeout middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a nice-grpc client middleware that sets a default timeout on
+ * every call via `AbortSignal.timeout()`.
+ *
+ * If the caller already supplied an `AbortSignal`, the timeout signal is
+ * combined with it using `AbortSignal.any()` so that either can cancel.
+ */
+export function timeoutMiddleware(timeoutMs: number): ClientMiddleware {
+  return async function* timeoutMw(call, options) {
+    if (options.signal) {
+      // Preserve the caller's signal while adding the timeout.
+      const combined = AbortSignal.any([
+        options.signal,
+        AbortSignal.timeout(timeoutMs),
+      ]);
+      return yield* call.next(call.request, {
+        ...options,
+        signal: combined,
+      });
+    }
+
+    return yield* call.next(call.request, {
+      ...options,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
   };
 }

--- a/src/transport/metadata.ts
+++ b/src/transport/metadata.ts
@@ -11,7 +11,10 @@ import {
   Metadata,
 } from "nice-grpc-common";
 import type { RetryOptions } from "../types/common.ts";
+import { readMetadataValue } from "../utils/grpc-metadata.ts";
 import { generateIdempotencyKey } from "../utils/idempotency.ts";
+import { DEFAULT_RETRY_OPTIONS } from "../utils/retry.ts";
+import { sleep } from "../utils/sleep.ts";
 
 // ---------------------------------------------------------------------------
 // Auth middleware
@@ -94,32 +97,6 @@ export function idempotencyMiddleware(): ClientMiddleware {
 // Retry middleware
 // ---------------------------------------------------------------------------
 
-/** Default retry settings (4 total attempts with exponential backoff). */
-const DEFAULT_MAX_ATTEMPTS = 4;
-const DEFAULT_INITIAL_DELAY = 200;
-const DEFAULT_MAX_DELAY = 5000;
-
-/**
- * Read a string value from gRPC trailing metadata attached to an error.
- */
-function readMetadataValue(error: unknown, key: string): string | undefined {
-  const meta = (error as { metadata?: { get(key: string): unknown[] } })
-    .metadata;
-  if (!meta || typeof meta.get !== "function") {
-    return undefined;
-  }
-  const values = meta.get(key);
-  if (!Array.isArray(values) || values.length === 0) {
-    return undefined;
-  }
-  const first = values[0];
-  return typeof first === "string" ? first : undefined;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise<void>((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * Creates a nice-grpc client middleware that automatically retries failed
  * unary calls when the server indicates the error is retryable (via the
@@ -129,9 +106,12 @@ function sleep(ms: number): Promise<void> {
  * through without retry.
  */
 export function retryMiddleware(opts: RetryOptions = {}): ClientMiddleware {
-  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  const initialDelay = opts.initialDelay ?? DEFAULT_INITIAL_DELAY;
-  const maxDelay = opts.maxDelay ?? DEFAULT_MAX_DELAY;
+  const maxAttempts = Math.max(
+    1,
+    opts.maxAttempts ?? DEFAULT_RETRY_OPTIONS.maxAttempts
+  );
+  const initialDelay = opts.initialDelay ?? DEFAULT_RETRY_OPTIONS.initialDelay;
+  const maxDelay = opts.maxDelay ?? DEFAULT_RETRY_OPTIONS.maxDelay;
 
   return async function* retryMw(call, options) {
     // Skip streaming calls — retrying mid-stream would duplicate data.
@@ -156,17 +136,18 @@ export function retryMiddleware(opts: RetryOptions = {}): ClientMiddleware {
         // Exponential backoff with full jitter.
         const exponentialDelay = initialDelay * 2 ** attempt;
         const cappedDelay = Math.min(exponentialDelay, maxDelay);
-        await sleep(Math.random() * cappedDelay);
+        await sleep(Math.random() * cappedDelay, options.signal);
+
+        // Stop retrying if the caller has cancelled.
+        if (options.signal?.aborted) {
+          throw error;
+        }
       }
     }
 
     throw lastError;
   };
 }
-
-// ---------------------------------------------------------------------------
-// Timeout middleware
-// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Trailing metadata capture middleware
@@ -225,13 +206,19 @@ export function trailingMetadataCaptureMiddleware(): ClientMiddleware {
 
 /**
  * Creates a nice-grpc client middleware that sets a default timeout on
- * every call via `AbortSignal.timeout()`.
+ * unary calls via `AbortSignal.timeout()`.  Streaming calls are passed
+ * through without a timeout to avoid killing long-lived subscriptions.
  *
  * If the caller already supplied an `AbortSignal`, the timeout signal is
  * combined with it using `AbortSignal.any()` so that either can cancel.
  */
 export function timeoutMiddleware(timeoutMs: number): ClientMiddleware {
   return async function* timeoutMw(call, options) {
+    // Skip streaming calls — a fixed timeout would kill long-lived streams.
+    if (call.method.responseStream || call.method.requestStream) {
+      return yield* call.next(call.request, options);
+    }
+
     if (options.signal) {
       // Preserve the caller's signal while adding the timeout.
       const combined = AbortSignal.any([

--- a/src/utils/grpc-metadata.ts
+++ b/src/utils/grpc-metadata.ts
@@ -1,0 +1,27 @@
+/**
+ * Read a string value from gRPC trailing metadata attached to an error.
+ *
+ * nice-grpc-common's `ClientError` does not expose metadata directly, so we
+ * also accept a raw `@grpc/grpc-js` status object (which carries a `metadata`
+ * field with a `.get()` method).
+ */
+export function readMetadataValue(
+  error: unknown,
+  key: string
+): string | undefined {
+  const meta = (error as { metadata?: { get(key: string): unknown[] } })
+    .metadata;
+
+  if (!meta || typeof meta.get !== "function") {
+    return undefined;
+  }
+
+  const values = meta.get(key);
+
+  if (!Array.isArray(values) || values.length === 0) {
+    return undefined;
+  }
+
+  const first = values[0];
+  return typeof first === "string" ? first : undefined;
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -6,10 +6,10 @@
  */
 
 import { IMessageError } from "../errors/imessage-error.ts";
+import type { RetryOptions } from "../types/common.ts";
+import { sleep } from "./sleep.ts";
 
 export type { RetryOptions } from "../types/common.ts";
-
-import type { RetryOptions } from "../types/common.ts";
 
 // ---------------------------------------------------------------------------
 // Options
@@ -41,7 +41,10 @@ export async function withRetry<T>(
   fn: () => Promise<T>,
   options: RetryOptions & { readonly signal?: AbortSignal } = {}
 ): Promise<T> {
-  const maxAttempts = options.maxAttempts ?? DEFAULT_RETRY_OPTIONS.maxAttempts;
+  const maxAttempts = Math.max(
+    1,
+    options.maxAttempts ?? DEFAULT_RETRY_OPTIONS.maxAttempts
+  );
   const initialDelay =
     options.initialDelay ?? DEFAULT_RETRY_OPTIONS.initialDelay;
   const maxDelay = options.maxDelay ?? DEFAULT_RETRY_OPTIONS.maxDelay;
@@ -77,32 +80,4 @@ export async function withRetry<T>(
 
   // Should be unreachable, but satisfies the type checker.
   throw lastError;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Sleep for the given number of milliseconds, aborting early if the signal
- * fires.
- */
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise<void>((resolve) => {
-    if (signal?.aborted) {
-      resolve();
-      return;
-    }
-
-    const timer = setTimeout(resolve, ms);
-
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true }
-    );
-  });
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -7,27 +7,21 @@
 
 import { IMessageError } from "../errors/imessage-error.ts";
 
+export type { RetryOptions } from "../types/common.ts";
+
+import type { RetryOptions } from "../types/common.ts";
+
 // ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
 
-/** Configuration for the retry behaviour. */
-export interface RetryOptions {
-  /** Base delay in milliseconds before the first retry. */
-  readonly baseDelayMs: number;
-  /** Maximum delay in milliseconds between retries. */
-  readonly maxDelayMs: number;
-  /** Maximum number of retry attempts (not including the initial call). */
-  readonly maxRetries: number;
-  /** Abort signal to cancel pending retries. */
-  readonly signal?: AbortSignal;
-}
-
 /** Sensible defaults for retry options. */
-export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
-  maxRetries: 3,
-  baseDelayMs: 200,
-  maxDelayMs: 5000,
+export const DEFAULT_RETRY_OPTIONS: Required<
+  Pick<RetryOptions, "initialDelay" | "maxAttempts" | "maxDelay">
+> = {
+  maxAttempts: 4,
+  initialDelay: 200,
+  maxDelay: 5000,
 };
 
 // ---------------------------------------------------------------------------
@@ -39,17 +33,22 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
  *
  * The function is invoked immediately. If it throws an {@link IMessageError}
  * whose `retryable` flag is `true`, the call is retried up to
- * `options.maxRetries` times with exponential backoff and full jitter.
+ * `maxAttempts - 1` times with exponential backoff and full jitter.
  *
  * Non-retryable errors are re-thrown immediately.
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
-  options: RetryOptions = DEFAULT_RETRY_OPTIONS
+  options: RetryOptions & { readonly signal?: AbortSignal } = {}
 ): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_RETRY_OPTIONS.maxAttempts;
+  const initialDelay =
+    options.initialDelay ?? DEFAULT_RETRY_OPTIONS.initialDelay;
+  const maxDelay = options.maxDelay ?? DEFAULT_RETRY_OPTIONS.maxDelay;
+
   let lastError: unknown;
 
-  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
       return await fn();
     } catch (error: unknown) {
@@ -58,7 +57,7 @@ export async function withRetry<T>(
       // Only retry IMessageError instances that are explicitly retryable.
       const isRetryable = error instanceof IMessageError && error.retryable;
 
-      if (!isRetryable || attempt >= options.maxRetries) {
+      if (!isRetryable || attempt >= maxAttempts - 1) {
         throw error;
       }
 
@@ -68,8 +67,8 @@ export async function withRetry<T>(
       }
 
       // Exponential backoff with full jitter.
-      const exponentialDelay = options.baseDelayMs * 2 ** attempt;
-      const cappedDelay = Math.min(exponentialDelay, options.maxDelayMs);
+      const exponentialDelay = initialDelay * 2 ** attempt;
+      const cappedDelay = Math.min(exponentialDelay, maxDelay);
       const jitteredDelay = Math.random() * cappedDelay;
 
       await sleep(jitteredDelay, options.signal);

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,23 @@
+/**
+ * Sleep for the given number of milliseconds, aborting early if the signal
+ * fires.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+
+    const timer = setTimeout(resolve, ms);
+
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -9,15 +9,16 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       return;
     }
 
-    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
 
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true }
-    );
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Unit tests for nice-grpc client middleware:
+ * - retryMiddleware
+ * - timeoutMiddleware
+ * - trailingMetadataCaptureMiddleware
+ *
+ * These tests use a mock middleware call chain that simulates nice-grpc
+ * behaviour without requiring an actual gRPC server.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import { type CallOptions, ClientError, Metadata, Status } from "nice-grpc-common";
+import type { RetryOptions } from "../../src/types/common.ts";
+import {
+  retryMiddleware,
+  timeoutMiddleware,
+  trailingMetadataCaptureMiddleware,
+} from "../../src/transport/metadata.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers — mock the nice-grpc middleware call/next interface
+// ---------------------------------------------------------------------------
+
+interface MockMethodDescriptor {
+  path: string;
+  requestStream: boolean;
+  responseStream: boolean;
+  options: Record<string, unknown>;
+}
+
+const UNARY_METHOD: MockMethodDescriptor = {
+  path: "/test.Service/Unary",
+  requestStream: false,
+  responseStream: false,
+  options: {},
+};
+
+const SERVER_STREAM_METHOD: MockMethodDescriptor = {
+  path: "/test.Service/ServerStream",
+  requestStream: false,
+  responseStream: true,
+  options: {},
+};
+
+/**
+ * Build a fake nice-grpc middleware `call` object whose `.next()` delegates
+ * to `handler`.  `handler` receives the request and options and should either
+ * return a value or throw.
+ */
+function buildCall<Req, Res>(
+  method: MockMethodDescriptor,
+  request: Req,
+  handler: (req: Req, opts: CallOptions) => Promise<Res>,
+) {
+  async function* nextFn(
+    req: Req | AsyncIterable<Req>,
+    opts: CallOptions,
+  ): AsyncGenerator<never, Res, undefined> {
+    return await handler(req as Req, opts);
+  }
+
+  return {
+    method,
+    request,
+    requestStream: method.requestStream,
+    responseStream: method.responseStream,
+    next: nextFn,
+  };
+}
+
+/** Drain an async generator, returning the final return value. */
+async function drain<T>(gen: AsyncGenerator<T, T | void, undefined>): Promise<T> {
+  let result = await gen.next();
+  while (!result.done) {
+    result = await gen.next();
+  }
+  return result.value as T;
+}
+
+/**
+ * Create a ClientError with fake trailing metadata attached (simulating
+ * what trailingMetadataCaptureMiddleware would produce).
+ */
+function errorWithMetadata(
+  code: number,
+  details: string,
+  meta: Record<string, string>,
+): ClientError {
+  const err = new ClientError("/test.Service/Unary", code, details);
+  Object.defineProperty(err, "metadata", {
+    value: {
+      get(key: string): unknown[] {
+        return key in meta ? [meta[key]] : [];
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+  return err;
+}
+
+// =========================================================================
+// trailingMetadataCaptureMiddleware
+// =========================================================================
+
+describe("trailingMetadataCaptureMiddleware", () => {
+  it("attaches trailing metadata to errors", async () => {
+    const mw = trailingMetadataCaptureMiddleware();
+
+    // Simulate a call that fails AND delivers trailing metadata via onTrailer
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      // Simulate the gRPC layer: fire onTrailer, then throw
+      const trailer = Metadata();
+      trailer.set("error-code", "chatNotFound");
+      trailer.set("x-retryable", "true");
+      opts.onTrailer?.(trailer);
+      throw new ClientError("/test.Service/Unary", Status.NOT_FOUND, "chat not found");
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+
+    try {
+      await drain(gen);
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(ClientError);
+      // Metadata adapter should be attached
+      expect(err.metadata).toBeDefined();
+      expect(err.metadata.get("error-code")).toEqual(["chatNotFound"]);
+      expect(err.metadata.get("x-retryable")).toEqual(["true"]);
+      expect(err.metadata.get("nonexistent")).toEqual([]);
+    }
+  });
+
+  it("preserves original onTrailer callback", async () => {
+    const mw = trailingMetadataCaptureMiddleware();
+    let callerTrailer: any;
+
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      const trailer = Metadata();
+      trailer.set("error-code", "timeout");
+      opts.onTrailer?.(trailer);
+      throw new ClientError("/test.Service/Unary", Status.DEADLINE_EXCEEDED, "timeout");
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {
+      onTrailer(t) {
+        callerTrailer = t;
+      },
+    });
+
+    try {
+      await drain(gen);
+    } catch {
+      // expected
+    }
+
+    expect(callerTrailer).toBeDefined();
+    expect(callerTrailer.get("error-code")).toBe("timeout");
+  });
+
+  it("passes through on success without modifying response", async () => {
+    const mw = trailingMetadataCaptureMiddleware();
+
+    const handler = async () => "ok";
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+    const result = await drain(gen);
+
+    expect(result).toBe("ok");
+  });
+});
+
+// =========================================================================
+// retryMiddleware
+// =========================================================================
+
+describe("retryMiddleware", () => {
+  it("retries on x-retryable errors up to maxAttempts", async () => {
+    const opts: RetryOptions = { maxAttempts: 3, initialDelay: 1, maxDelay: 1 };
+    const mw = retryMiddleware(opts);
+
+    let attempts = 0;
+    const handler = async () => {
+      attempts++;
+      if (attempts < 3) {
+        throw errorWithMetadata(Status.UNAVAILABLE, "unavailable", {
+          "x-retryable": "true",
+        });
+      }
+      return "success";
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+    const result = await drain(gen);
+
+    expect(result).toBe("success");
+    expect(attempts).toBe(3);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const opts: RetryOptions = { maxAttempts: 3, initialDelay: 1, maxDelay: 1 };
+    const mw = retryMiddleware(opts);
+
+    let attempts = 0;
+    const handler = async () => {
+      attempts++;
+      throw errorWithMetadata(Status.NOT_FOUND, "not found", {});
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+
+    try {
+      await drain(gen);
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(ClientError);
+      expect(err.details).toBe("not found");
+    }
+
+    expect(attempts).toBe(1);
+  });
+
+  it("throws after exhausting all attempts", async () => {
+    const opts: RetryOptions = { maxAttempts: 2, initialDelay: 1, maxDelay: 1 };
+    const mw = retryMiddleware(opts);
+
+    let attempts = 0;
+    const handler = async () => {
+      attempts++;
+      throw errorWithMetadata(Status.UNAVAILABLE, `fail ${attempts}`, {
+        "x-retryable": "true",
+      });
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+
+    try {
+      await drain(gen);
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err.details).toBe("fail 2");
+    }
+
+    expect(attempts).toBe(2);
+  });
+
+  it("skips retry for streaming calls", async () => {
+    const opts: RetryOptions = { maxAttempts: 3, initialDelay: 1, maxDelay: 1 };
+    const mw = retryMiddleware(opts);
+
+    let attempts = 0;
+    const handler = async () => {
+      attempts++;
+      throw errorWithMetadata(Status.UNAVAILABLE, "unavailable", {
+        "x-retryable": "true",
+      });
+    };
+
+    const call = buildCall(SERVER_STREAM_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+
+    try {
+      await drain(gen);
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err.details).toBe("unavailable");
+    }
+
+    // Should only attempt once — no retry for streaming
+    expect(attempts).toBe(1);
+  });
+
+  it("uses default options when none provided", async () => {
+    const mw = retryMiddleware();
+
+    let attempts = 0;
+    const handler = async () => {
+      attempts++;
+      if (attempts < 4) {
+        throw errorWithMetadata(Status.UNAVAILABLE, "unavailable", {
+          "x-retryable": "true",
+        });
+      }
+      return "success";
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    // Use very short delays to speed up the test — but default middleware
+    // uses 200ms base delay. We test with explicit opts in other tests.
+    // Here we just verify it doesn't crash with defaults.
+    // Actually, defaults have real delays. Let's use explicit opts.
+    // Test that the constructor doesn't blow up:
+    expect(mw).toBeFunction();
+  });
+});
+
+// =========================================================================
+// timeoutMiddleware
+// =========================================================================
+
+describe("timeoutMiddleware", () => {
+  it("sets AbortSignal.timeout on calls without existing signal", async () => {
+    const mw = timeoutMiddleware(5000);
+
+    let receivedSignal: AbortSignal | undefined;
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      receivedSignal = opts.signal;
+      return "ok";
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+    const result = await drain(gen);
+
+    expect(result).toBe("ok");
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal!.aborted).toBe(false);
+  });
+
+  it("combines with existing caller signal", async () => {
+    const mw = timeoutMiddleware(5000);
+    const callerAbort = new AbortController();
+
+    let receivedSignal: AbortSignal | undefined;
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      receivedSignal = opts.signal;
+      return "ok";
+    };
+
+    const call = buildCall(UNARY_METHOD, {}, handler);
+    const gen = mw(call as any, { signal: callerAbort.signal });
+    await drain(gen);
+
+    expect(receivedSignal).toBeDefined();
+    // The received signal should be a combined signal (not the original)
+    expect(receivedSignal).not.toBe(callerAbort.signal);
+    expect(receivedSignal!.aborted).toBe(false);
+
+    // Aborting the caller's signal should propagate
+    callerAbort.abort();
+    expect(receivedSignal!.aborted).toBe(true);
+  });
+});
+
+// =========================================================================
+// Integration: capture + retry working together
+// =========================================================================
+
+describe("trailingMetadataCapture + retry integration", () => {
+  it("retry reads x-retryable from captured trailing metadata", async () => {
+    const captureMw = trailingMetadataCaptureMiddleware();
+    const retryMw = retryMiddleware({ maxAttempts: 3, initialDelay: 1, maxDelay: 1 });
+
+    let attempts = 0;
+
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      attempts++;
+      // Simulate server: deliver trailing metadata, then error
+      const trailer = Metadata();
+      if (attempts < 3) {
+        trailer.set("x-retryable", "true");
+        trailer.set("error-code", "serviceUnavailable");
+      } else {
+        trailer.set("error-code", "ok");
+      }
+      opts.onTrailer?.(trailer);
+
+      if (attempts < 3) {
+        throw new ClientError("/test.Service/Unary", Status.UNAVAILABLE, "unavailable");
+      }
+      return "success";
+    };
+
+    // Build a chained middleware: retry(outer) → capture(inner) → handler
+    // We simulate this by nesting: retry calls capture's generator which calls handler
+
+    // Inner: capture wraps handler
+    const innerCall = buildCall(UNARY_METHOD, {}, handler);
+    const captureGen = (req: unknown, opts: CallOptions) => captureMw(innerCall as any, opts);
+
+    // Outer: retry wraps capture
+    const outerCall = {
+      method: UNARY_METHOD,
+      request: {},
+      requestStream: false,
+      responseStream: false,
+      next: captureGen as any,
+    };
+
+    const gen = retryMw(outerCall as any, {});
+    const result = await drain(gen);
+
+    expect(result).toBe("success");
+    expect(attempts).toBe(3);
+  });
+});

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -8,24 +8,29 @@
  * behaviour without requiring an actual gRPC server.
  */
 
-import { describe, expect, it, mock } from "bun:test";
-import { type CallOptions, ClientError, Metadata, Status } from "nice-grpc-common";
-import type { RetryOptions } from "../../src/types/common.ts";
+import { describe, expect, it } from "bun:test";
+import {
+  type CallOptions,
+  ClientError,
+  Metadata,
+  Status,
+} from "nice-grpc-common";
 import {
   retryMiddleware,
   timeoutMiddleware,
   trailingMetadataCaptureMiddleware,
 } from "../../src/transport/metadata.ts";
+import type { RetryOptions } from "../../src/types/common.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers — mock the nice-grpc middleware call/next interface
 // ---------------------------------------------------------------------------
 
 interface MockMethodDescriptor {
+  options: Record<string, unknown>;
   path: string;
   requestStream: boolean;
   responseStream: boolean;
-  options: Record<string, unknown>;
 }
 
 const UNARY_METHOD: MockMethodDescriptor = {
@@ -50,11 +55,12 @@ const SERVER_STREAM_METHOD: MockMethodDescriptor = {
 function buildCall<Req, Res>(
   method: MockMethodDescriptor,
   request: Req,
-  handler: (req: Req, opts: CallOptions) => Promise<Res>,
+  handler: (req: Req, opts: CallOptions) => Promise<Res>
 ) {
+  // biome-ignore lint/correctness/useYield: simulates nice-grpc async generator interface
   async function* nextFn(
     req: Req | AsyncIterable<Req>,
-    opts: CallOptions,
+    opts: CallOptions
   ): AsyncGenerator<never, Res, undefined> {
     return await handler(req as Req, opts);
   }
@@ -69,7 +75,9 @@ function buildCall<Req, Res>(
 }
 
 /** Drain an async generator, returning the final return value. */
-async function drain<T>(gen: AsyncGenerator<T, T | void, undefined>): Promise<T> {
+async function drain<T>(
+  gen: AsyncGenerator<T, T | undefined, undefined>
+): Promise<T> {
   let result = await gen.next();
   while (!result.done) {
     result = await gen.next();
@@ -84,7 +92,7 @@ async function drain<T>(gen: AsyncGenerator<T, T | void, undefined>): Promise<T>
 function errorWithMetadata(
   code: number,
   details: string,
-  meta: Record<string, string>,
+  meta: Record<string, string>
 ): ClientError {
   const err = new ClientError("/test.Service/Unary", code, details);
   Object.defineProperty(err, "metadata", {
@@ -114,7 +122,11 @@ describe("trailingMetadataCaptureMiddleware", () => {
       trailer.set("error-code", "chatNotFound");
       trailer.set("x-retryable", "true");
       opts.onTrailer?.(trailer);
-      throw new ClientError("/test.Service/Unary", Status.NOT_FOUND, "chat not found");
+      throw new ClientError(
+        "/test.Service/Unary",
+        Status.NOT_FOUND,
+        "chat not found"
+      );
     };
 
     const call = buildCall(UNARY_METHOD, {}, handler);
@@ -141,7 +153,11 @@ describe("trailingMetadataCaptureMiddleware", () => {
       const trailer = Metadata();
       trailer.set("error-code", "timeout");
       opts.onTrailer?.(trailer);
-      throw new ClientError("/test.Service/Unary", Status.DEADLINE_EXCEEDED, "timeout");
+      throw new ClientError(
+        "/test.Service/Unary",
+        Status.DEADLINE_EXCEEDED,
+        "timeout"
+      );
     };
 
     const call = buildCall(UNARY_METHOD, {}, handler);
@@ -276,26 +292,8 @@ describe("retryMiddleware", () => {
     expect(attempts).toBe(1);
   });
 
-  it("uses default options when none provided", async () => {
+  it("uses default options when none provided", () => {
     const mw = retryMiddleware();
-
-    let attempts = 0;
-    const handler = async () => {
-      attempts++;
-      if (attempts < 4) {
-        throw errorWithMetadata(Status.UNAVAILABLE, "unavailable", {
-          "x-retryable": "true",
-        });
-      }
-      return "success";
-    };
-
-    const call = buildCall(UNARY_METHOD, {}, handler);
-    // Use very short delays to speed up the test — but default middleware
-    // uses 200ms base delay. We test with explicit opts in other tests.
-    // Here we just verify it doesn't crash with defaults.
-    // Actually, defaults have real delays. Let's use explicit opts.
-    // Test that the constructor doesn't blow up:
     expect(mw).toBeFunction();
   });
 });
@@ -320,7 +318,25 @@ describe("timeoutMiddleware", () => {
 
     expect(result).toBe("ok");
     expect(receivedSignal).toBeDefined();
-    expect(receivedSignal!.aborted).toBe(false);
+    expect(receivedSignal?.aborted).toBe(false);
+  });
+
+  it("skips streaming calls", async () => {
+    const mw = timeoutMiddleware(5000);
+
+    let receivedSignal: AbortSignal | undefined;
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      receivedSignal = opts.signal;
+      return "ok";
+    };
+
+    const call = buildCall(SERVER_STREAM_METHOD, {}, handler);
+    const gen = mw(call as any, {});
+    const result = await drain(gen);
+
+    expect(result).toBe("ok");
+    // Streaming calls should NOT get a timeout signal
+    expect(receivedSignal).toBeUndefined();
   });
 
   it("combines with existing caller signal", async () => {
@@ -340,11 +356,11 @@ describe("timeoutMiddleware", () => {
     expect(receivedSignal).toBeDefined();
     // The received signal should be a combined signal (not the original)
     expect(receivedSignal).not.toBe(callerAbort.signal);
-    expect(receivedSignal!.aborted).toBe(false);
+    expect(receivedSignal?.aborted).toBe(false);
 
     // Aborting the caller's signal should propagate
     callerAbort.abort();
-    expect(receivedSignal!.aborted).toBe(true);
+    expect(receivedSignal?.aborted).toBe(true);
   });
 });
 
@@ -355,7 +371,11 @@ describe("timeoutMiddleware", () => {
 describe("trailingMetadataCapture + retry integration", () => {
   it("retry reads x-retryable from captured trailing metadata", async () => {
     const captureMw = trailingMetadataCaptureMiddleware();
-    const retryMw = retryMiddleware({ maxAttempts: 3, initialDelay: 1, maxDelay: 1 });
+    const retryMw = retryMiddleware({
+      maxAttempts: 3,
+      initialDelay: 1,
+      maxDelay: 1,
+    });
 
     let attempts = 0;
 
@@ -372,7 +392,11 @@ describe("trailingMetadataCapture + retry integration", () => {
       opts.onTrailer?.(trailer);
 
       if (attempts < 3) {
-        throw new ClientError("/test.Service/Unary", Status.UNAVAILABLE, "unavailable");
+        throw new ClientError(
+          "/test.Service/Unary",
+          Status.UNAVAILABLE,
+          "unavailable"
+        );
       }
       return "success";
     };
@@ -382,7 +406,8 @@ describe("trailingMetadataCapture + retry integration", () => {
 
     // Inner: capture wraps handler
     const innerCall = buildCall(UNARY_METHOD, {}, handler);
-    const captureGen = (req: unknown, opts: CallOptions) => captureMw(innerCall as any, opts);
+    const captureGen = (_req: unknown, opts: CallOptions) =>
+      captureMw(innerCall as any, opts);
 
     // Outer: retry wraps capture
     const outerCall = {

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the withRetry utility function.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { IMessageError } from "../../src/errors/imessage-error.ts";
+import { withRetry } from "../../src/utils/retry.ts";
+
+describe("withRetry", () => {
+  it("returns immediately on success", async () => {
+    let calls = 0;
+    const result = await withRetry(async () => {
+      calls++;
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries retryable IMessageError up to maxAttempts", async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) {
+          throw new IMessageError("transient", {
+            code: "serviceUnavailable" as any,
+            retryable: true,
+            grpcCode: 14,
+          });
+        }
+        return "recovered";
+      },
+      { maxAttempts: 4, initialDelay: 1, maxDelay: 1 },
+    );
+
+    expect(result).toBe("recovered");
+    expect(calls).toBe(3);
+  });
+
+  it("does not retry non-retryable IMessageError", async () => {
+    let calls = 0;
+    try {
+      await withRetry(
+        async () => {
+          calls++;
+          throw new IMessageError("permanent", {
+            code: "chatNotFound" as any,
+            retryable: false,
+            grpcCode: 5,
+          });
+        },
+        { maxAttempts: 3, initialDelay: 1, maxDelay: 1 },
+      );
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(IMessageError);
+      expect(err.message).toBe("permanent");
+    }
+    expect(calls).toBe(1);
+  });
+
+  it("does not retry non-IMessageError errors", async () => {
+    let calls = 0;
+    try {
+      await withRetry(
+        async () => {
+          calls++;
+          throw new Error("generic");
+        },
+        { maxAttempts: 3, initialDelay: 1, maxDelay: 1 },
+      );
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err.message).toBe("generic");
+    }
+    expect(calls).toBe(1);
+  });
+
+  it("throws after exhausting all attempts", async () => {
+    let calls = 0;
+    try {
+      await withRetry(
+        async () => {
+          calls++;
+          throw new IMessageError(`fail ${calls}`, {
+            code: "serviceUnavailable" as any,
+            retryable: true,
+            grpcCode: 14,
+          });
+        },
+        { maxAttempts: 2, initialDelay: 1, maxDelay: 1 },
+      );
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err.message).toBe("fail 2");
+    }
+    expect(calls).toBe(2);
+  });
+
+  it("aborts early when signal is aborted", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+
+    // Abort after first failure
+    try {
+      await withRetry(
+        async () => {
+          calls++;
+          controller.abort();
+          throw new IMessageError("transient", {
+            code: "serviceUnavailable" as any,
+            retryable: true,
+            grpcCode: 14,
+          });
+        },
+        { maxAttempts: 5, initialDelay: 1, maxDelay: 1, signal: controller.signal },
+      );
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(IMessageError);
+    }
+    expect(calls).toBe(1);
+  });
+
+  it("uses default options when none provided", async () => {
+    // Just verify it doesn't throw with default options on a success case
+    const result = await withRetry(async () => "ok");
+    expect(result).toBe("ok");
+  });
+});

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -31,7 +31,7 @@ describe("withRetry", () => {
         }
         return "recovered";
       },
-      { maxAttempts: 4, initialDelay: 1, maxDelay: 1 },
+      { maxAttempts: 4, initialDelay: 1, maxDelay: 1 }
     );
 
     expect(result).toBe("recovered");
@@ -50,7 +50,7 @@ describe("withRetry", () => {
             grpcCode: 5,
           });
         },
-        { maxAttempts: 3, initialDelay: 1, maxDelay: 1 },
+        { maxAttempts: 3, initialDelay: 1, maxDelay: 1 }
       );
       throw new Error("should have thrown");
     } catch (err: any) {
@@ -68,7 +68,7 @@ describe("withRetry", () => {
           calls++;
           throw new Error("generic");
         },
-        { maxAttempts: 3, initialDelay: 1, maxDelay: 1 },
+        { maxAttempts: 3, initialDelay: 1, maxDelay: 1 }
       );
       throw new Error("should have thrown");
     } catch (err: any) {
@@ -89,7 +89,7 @@ describe("withRetry", () => {
             grpcCode: 14,
           });
         },
-        { maxAttempts: 2, initialDelay: 1, maxDelay: 1 },
+        { maxAttempts: 2, initialDelay: 1, maxDelay: 1 }
       );
       throw new Error("should have thrown");
     } catch (err: any) {
@@ -114,7 +114,12 @@ describe("withRetry", () => {
             grpcCode: 14,
           });
         },
-        { maxAttempts: 5, initialDelay: 1, maxDelay: 1, signal: controller.signal },
+        {
+          maxAttempts: 5,
+          initialDelay: 1,
+          maxDelay: 1,
+          signal: controller.signal,
+        }
       );
       throw new Error("should have thrown");
     } catch (err: any) {


### PR DESCRIPTION
## Summary

  - **Bug**: `ClientOptions.retry` and `ClientOptions.timeout` were declared but never passed through to `createGrpcClients`, so they had no effect
  - **Bug**: nice-grpc `wrapClientError` drops trailing metadata from gRPC errors, making `x-retryable` and `error-code` headers from the server permanently unreadable
  - Adds `retryMiddleware` — exponential backoff with full jitter, driven by server `x-retryable` trailing metadata, skips streaming calls
  - Adds `timeoutMiddleware` — sets `AbortSignal.timeout()`, combines with caller signal via `AbortSignal.any()`
  - Adds `trailingMetadataCaptureMiddleware` — captures trailing metadata via `onTrailer` and re-attaches it to errors so outer middleware can read it
  - Aligns `utils/retry.ts` internal field names (`baseDelayMs`/`maxRetries`/`maxDelayMs`) with the public `RetryOptions` API (`initialDelay`/`maxAttempts`/`maxDelay`)

  ## Test plan

  - [ ] 18 new unit tests pass (`bun test tests/unit/middleware.test.ts tests/unit/retry.test.ts`)
  - [ ] Verify middleware chain order: `idempotency → retry → timeout → auth → trailingMetadataCapture → RPC`
  - [ ] Integration test confirms capture + retry work end-to-end (retry reads `x-retryable` from captured trailer)
  - [ ] Existing tests unaffected
  
  Fix ENG-1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client now applies retry and timeout settings at the transport layer for unary calls
  * Transport middleware: configurable retry with exponential backoff, per-call timeout, and trailing-metadata capture
  * Added a lightweight sleep utility used by retry/backoff logic

* **Bug Fixes**
  * More reliable extraction of server trailing metadata from gRPC errors

* **Tests**
  * Comprehensive unit tests covering retry, timeout, and metadata middleware behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->