### PR TITLE
feat: guarantee per-chat message ordering via promise chains

### DIFF
--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -45,6 +45,9 @@ import { unwrap } from "../utils/unwrap.ts";
 // Helpers
 // ---------------------------------------------------------------------------
 
+// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional noop for promise chain suppression
+function noop(): void {}
+
 /**
  * Convert SDK TextFormatInput[] to proto TextFormat[].
  */
@@ -104,9 +107,38 @@ function resolveReplyTo(
 
 export class MessagesResource {
   private readonly _client: MessageServiceClient;
+  private readonly _chains = new Map<string, Promise<void>>();
 
   constructor(client: MessageServiceClient) {
     this._client = client;
+  }
+
+  // -------------------------------------------------------------------------
+  // Ordering internals
+  // -------------------------------------------------------------------------
+
+  /**
+   * Chain a send onto the per-chat promise queue. Sends to the same chat
+   * execute sequentially; different chats proceed concurrently.
+   */
+  private _enqueue<T>(chat: ChatGuid, fn: () => Promise<T>): Promise<T> {
+    const prev = this._chains.get(chat) ?? Promise.resolve();
+
+    const task = prev.then(
+      () => fn(),
+      () => fn()
+    );
+
+    const chain = task.then(noop, noop);
+    this._chains.set(chat, chain);
+
+    chain.then(() => {
+      if (this._chains.get(chat) === chain) {
+        this._chains.delete(chat);
+      }
+    });
+
+    return task;
   }
 
   // -------------------------------------------------------------------------
@@ -116,7 +148,15 @@ export class MessagesResource {
   /**
    * Send a plain-text message to a chat (Tier 1 / Tier 2 API).
    */
-  async send(
+  send(
+    chat: ChatGuid,
+    text: string,
+    options?: SendOptions
+  ): Promise<SendReceipt> {
+    return this._enqueue(chat, () => this._doSend(chat, text, options));
+  }
+
+  private async _doSend(
     chat: ChatGuid,
     text: string,
     options?: SendOptions
@@ -170,7 +210,17 @@ export class MessagesResource {
    * a single text string. Formatting is specified per-part rather than at
    * the top level.
    */
-  async sendMultipart(
+  sendMultipart(
+    chat: ChatGuid,
+    parts: MessagePart[],
+    options?: Omit<SendOptions, "formatting">
+  ): Promise<SendReceipt> {
+    return this._enqueue(chat, () =>
+      this._doSendMultipart(chat, parts, options)
+    );
+  }
+
+  private async _doSendMultipart(
     chat: ChatGuid,
     parts: MessagePart[],
     options?: Omit<SendOptions, "formatting">
@@ -221,7 +271,11 @@ export class MessagesResource {
    *
    * Accepts a `ComposedMessage` typically produced by `MessageBuilder`.
    */
-  async sendComposed(
+  sendComposed(chat: ChatGuid, message: ComposedMessage): Promise<SendReceipt> {
+    return this._enqueue(chat, () => this._doSendComposed(chat, message));
+  }
+
+  private async _doSendComposed(
     chat: ChatGuid,
     message: ComposedMessage
   ): Promise<SendReceipt> {

--- a/tests/unit/ordered-send.test.ts
+++ b/tests/unit/ordered-send.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for per-chat ordered send in MessagesResource.
+ *
+ * Sends to the same chat are always serialised; different chats are concurrent.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { MessagesResource } from "../../src/resources/messages.ts";
+import type { ChatGuid } from "../../src/types/branded.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockClient(delay = 0) {
+  const calls: Array<{ chat: string; order: number }> = [];
+  let callCount = 0;
+  const inFlight = { current: 0, peak: 0 };
+
+  const client = {
+    send: async (request: { chatGuid: string }) => {
+      const order = callCount++;
+      calls.push({ chat: request.chatGuid, order });
+      inFlight.current++;
+      inFlight.peak = Math.max(inFlight.peak, inFlight.current);
+      if (delay > 0) {
+        await new Promise((r) => setTimeout(r, delay));
+      }
+      inFlight.current--;
+      return {
+        receipt: { guid: `msg-${order}`, clientMessageId: undefined },
+      };
+    },
+  };
+
+  return { client: client as any, calls, inFlight };
+}
+
+function createFailingClient(failOnCall: number) {
+  let callCount = 0;
+  const calls: number[] = [];
+
+  const client = {
+    send: async (_request: { chatGuid: string }) => {
+      const order = callCount++;
+      calls.push(order);
+      if (order === failOnCall) {
+        throw new Error("test failure");
+      }
+      return {
+        receipt: { guid: `msg-${order}`, clientMessageId: undefined },
+      };
+    },
+  };
+
+  return { client: client as any, calls };
+}
+
+const chatA = "iMessage;-;alice@icloud.com" as ChatGuid;
+const chatB = "iMessage;-;bob@icloud.com" as ChatGuid;
+const chatC = "iMessage;-;charlie@icloud.com" as ChatGuid;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MessagesResource ordered send", () => {
+  it("preserves order for same-chat sends", async () => {
+    const { client, calls } = createMockClient(10);
+    const messages = new MessagesResource(client);
+
+    const p1 = messages.send(chatA, "first");
+    const p2 = messages.send(chatA, "second");
+    const p3 = messages.send(chatA, "third");
+
+    await Promise.all([p1, p2, p3]);
+
+    const chatACalls = calls.filter((c) => c.chat === chatA);
+    expect(chatACalls.map((c) => c.order)).toEqual([0, 1, 2]);
+  });
+
+  it("allows concurrent sends to different chats", async () => {
+    const { client, inFlight } = createMockClient(20);
+    const messages = new MessagesResource(client);
+
+    const p1 = messages.send(chatA, "to A");
+    const p2 = messages.send(chatB, "to B");
+    const p3 = messages.send(chatC, "to C");
+
+    await Promise.all([p1, p2, p3]);
+
+    expect(inFlight.peak).toBe(3);
+  });
+
+  it("continues after a preceding message fails", async () => {
+    const { client, calls } = createFailingClient(0);
+    const messages = new MessagesResource(client);
+
+    const p1 = messages.send(chatA, "will fail");
+    const p2 = messages.send(chatA, "should succeed");
+
+    await expect(p1).rejects.toThrow();
+    const receipt = await p2;
+    expect(receipt.guid).toBeDefined();
+
+    expect(calls).toEqual([0, 1]);
+  });
+
+  it("cleans up chain entries after completion", async () => {
+    const { client } = createMockClient();
+    const messages = new MessagesResource(client);
+
+    await messages.send(chatA, "hello");
+
+    // Flush microtask queue for the chain cleanup callback.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const chains = (messages as any)._chains as Map<string, Promise<void>>;
+    expect(chains.size).toBe(0);
+  });
+
+  it("returns correct receipts for each send", async () => {
+    const { client } = createMockClient(5);
+    const messages = new MessagesResource(client);
+
+    const p1 = messages.send(chatA, "first");
+    const p2 = messages.send(chatA, "second");
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.guid).toBe("msg-0");
+    expect(r2.guid).toBe("msg-1");
+  });
+});


### PR DESCRIPTION
## Summary

  - Sends to the **same chat** are automatically queued so they arrive in the exact order `.send()` was called — no config, no opt-in
  - Sends to **different chats** remain fully concurrent (independent chains)
  - A failed message does **not** block subsequent messages in the same chat
  - Zero public API surface change; zero new dependencies

  ## Test plan

  - [x] Unit tests: ordering, concurrency, failure isolation, chain cleanup, receipt correctness (`tests/unit/ordered-send.test.ts`)
  - [x] Integration stress test against live server: 10-msg ordering, 20-msg burst, multi-chat interleave, 50-msg heavy load (`tests/integration/stress-send.ts`)
  - [x] `bun test` — 27 tests pass
  - [x] `bun x tsc --noEmit` — type check clean
  - [x] `bun x ultracite check` — lint clean
  
  Fix ENG-1131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented sequential message delivery within each chat while enabling concurrent sends across different chats for improved performance.
  * Updated message sending method signatures for enhanced clarity.

* **Tests**
  * Added comprehensive test coverage for sequential delivery behavior and concurrent message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->