### PR TITLE
ci: add release and docs-update workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,15 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    uses: photon-hq/buildspace/.github/workflows/typescript-service-release.yaml@main
+    permissions:
+      contents: write
+      pull-requests: read
+    with:
+      service-name: advanced-imessage
+    secrets: inherit

--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -1,0 +1,12 @@
+name: Update Docs on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-docs:
+    uses: photon-hq/buildspace/.github/workflows/update-docs.yaml@main
+    with:
+      docs-path: advanced-kits/imessage
+    secrets: inherit


### PR DESCRIPTION
## Summary

  - Add `release.yaml` — triggers on push to main, delegates to `buildspace/typescript-service-release` for version
  bumping, GitHub release creation, and npm publishing
  - Add `update-docs.yaml` — triggers on release published, delegates to `buildspace/update-docs` for AI-powered documentation updates via Claude Code
  - All secrets use `secrets: inherit`; only `NPM_TOKEN` needs to be configured as a repo-level secret

  ## Test plan

  - [ ] Verify `NPM_TOKEN` is configured in repo Settings →
  Secrets
  - [ ] Merge a PR with `release` label and confirm the full pipeline:
        build → GitHub release → npm publish → docs PR created
        
        
 Fix  ENG-1135