### PR TITLE
chore: add MIT license and package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Photon AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,20 @@
 {
   "name": "@photon-ai/advanced-imessage",
   "version": "0.1.0",
+  "description": "TypeScript SDK for Advanced iMessage API",
+  "author": "Photon AI",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/photon-hq/advanced-imessage-ts.git"
+  },
+  "keywords": [
+    "imessage",
+    "sdk",
+    "grpc",
+    "typescript",
+    "apple"
+  ],
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

  - Add MIT license file
  - Add package metadata to `package.json`: description, author, license, repository URL, and keywords

  ## Test plan

  - [x] Verify `npm pack --dry-run` includes LICENSE in tarball
  - [x] Confirm metadata renders correctly on npmjs.com after next publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT License with 2026 copyright notice, providing full legal terms, conditions, warranty disclaimers, and limitation of liability guidance for project usage
  * Enriched package metadata by incorporating author details, license designation, repository information, and searchable keywords, thereby improving package discovery capabilities and providing more complete project information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->