### PR TITLE
feat: structured rich content parsing for messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,18 +81,7 @@ export type {
 } from "./types/events.js";
 export type { BackgroundInfo } from "./types/groups.js";
 export type { FindMyFriend } from "./types/locations.js";
-// Domain types
-export type {
-  ComposedMessage,
-  EmbeddedMediaItem,
-  Message,
-  MessageListOptions,
-  MessagePart,
-  MessageStats,
-  SendOptions,
-  StickerPlacement,
-  TextFormatInput,
-} from "./types/messages.js";
+export * from "./types/messages.js";
 export type { PollInfo, PollOption, PollVote } from "./types/polls.js";
 export { Reaction } from "./types/reactions.js";
 export type {
@@ -101,3 +90,4 @@ export type {
   ScheduledMessagePayload,
   UpdateScheduledMessageOptions,
 } from "./types/scheduled-messages.js";
+export { parseVCard } from "./utils/payload.js";

--- a/src/transport/mapper.ts
+++ b/src/transport/mapper.ts
@@ -59,9 +59,18 @@ import type {
   TransferState,
 } from "../types/enums.ts";
 import type { FindMyFriend } from "../types/locations.ts";
-import type { Message } from "../types/messages.ts";
+import type { Message, MessageContent } from "../types/messages.ts";
 import type { PollInfo, PollOption, PollVote } from "../types/polls.ts";
+import type { Reaction } from "../types/reactions.ts";
 import type { ScheduledMessage } from "../types/scheduled-messages.ts";
+import {
+  decompressPayload,
+  extractCheckin,
+  extractCollaboration,
+  extractLocationShare,
+  extractOriginalText,
+  extractRichLink,
+} from "../utils/payload.ts";
 
 // ---------------------------------------------------------------------------
 // Timestamp conversion
@@ -244,6 +253,300 @@ export function mapAttachmentInfo(proto: ProtoAttachmentInfo): AttachmentInfo {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Content resolution
+// ---------------------------------------------------------------------------
+
+/** 2000-2005 = add, 3000-3005 = remove. Last digit indexes into this array. */
+const TAPBACK_REACTIONS: readonly Reaction[] = [
+  "love",
+  "like",
+  "dislike",
+  "laugh",
+  "emphasize",
+  "question",
+];
+
+const TAPBACK_PART_RE = /^p:(\d+)\//;
+
+const BALLOON_RICH_LINK = "com.apple.messages.URLBalloonProvider";
+const BALLOON_CHECKIN =
+  "com.apple.SafetyMonitorPlugin.SafetyMonitorMessageExtension";
+const BALLOON_LOCATION = "com.apple.locationsharing";
+const BALLOON_POLL = "com.apple.messages.PollBalloonProvider";
+const BALLOON_COLLAB_PREFIX =
+  "com.apple.messages.MSMessageExtensionBalloonPlugin:";
+
+const IMAGE_SUBTYPE_MAP: Record<
+  string,
+  "gif" | "png" | "heic" | "jpeg" | "webp"
+> = {
+  "image/gif": "gif",
+  "image/png": "png",
+  "image/heic": "heic",
+  "image/jpeg": "jpeg",
+  "image/webp": "webp",
+};
+
+/** Priority: unsend > reaction > edit > system > balloon > attachment > text > unknown */
+function resolveContent(
+  proto: ProtoMessage,
+  mappedAttachments: readonly AttachmentInfo[]
+): MessageContent {
+  if (proto.dateRetracted) {
+    return { type: "unsend", retractedAt: proto.dateRetracted };
+  }
+
+  const reactionResult = resolveReaction(proto);
+  if (reactionResult) {
+    return reactionResult;
+  }
+
+  if (proto.dateEdited) {
+    return resolveEdit(proto);
+  }
+
+  if (
+    proto.isSystemMessage ||
+    proto.itemType !== ProtoMessageItemType.MESSAGE_ITEM_TYPE_NORMAL
+  ) {
+    return resolveSystem(proto);
+  }
+
+  const balloonResult = resolveBalloon(proto);
+  if (balloonResult) {
+    return balloonResult;
+  }
+
+  const attachmentResult = resolveAttachment(proto, mappedAttachments);
+  if (attachmentResult) {
+    return attachmentResult;
+  }
+
+  if (proto.text) {
+    return {
+      type: "text",
+      text: proto.text,
+      effect: proto.expressiveSendStyleId,
+    };
+  }
+
+  return { type: "unknown" };
+}
+
+function resolveReaction(proto: ProtoMessage): MessageContent | undefined {
+  if (!proto.associatedMessageType) {
+    return undefined;
+  }
+
+  const code = Number.parseInt(proto.associatedMessageType, 10);
+  if (Number.isNaN(code) || code < 2000 || code > 3005) {
+    return undefined;
+  }
+
+  const isRemoval = code >= 3000;
+  const reactionIdx = (code % 1000) % 6;
+  const reaction = TAPBACK_REACTIONS[reactionIdx] ?? "love";
+
+  let targetGuid = proto.associatedMessageGuid ?? "";
+  let targetPart = 0;
+  const partMatch = TAPBACK_PART_RE.exec(targetGuid);
+  if (partMatch) {
+    targetPart = Number.parseInt(partMatch[1] ?? "0", 10);
+    targetGuid = targetGuid.slice(partMatch[0].length);
+  }
+
+  return {
+    type: "reaction",
+    reaction,
+    emoji: proto.associatedMessageEmoji,
+    isRemoval,
+    targetGuid: messageGuid(targetGuid),
+    targetPart,
+  };
+}
+
+function resolveEdit(proto: ProtoMessage): MessageContent {
+  const originalText = proto.messageSummaryInfo
+    ? extractOriginalText(proto.messageSummaryInfo)
+    : undefined;
+  return {
+    type: "edit",
+    editedAt: proto.dateEdited ?? new Date(0),
+    newText: proto.text ?? "",
+    originalText,
+  };
+}
+
+function resolveSystem(proto: ProtoMessage): MessageContent {
+  const itemType = mapMessageItemType(proto.itemType);
+  const systemType = itemType === "normal" ? "other" : itemType;
+  return { type: "system", groupTitle: proto.groupTitle, systemType };
+}
+
+function resolveBalloon(proto: ProtoMessage): MessageContent | undefined {
+  if (!proto.balloonBundleId) {
+    return undefined;
+  }
+
+  const balloon = proto.balloonBundleId;
+  const rawPayload = proto.payloadData;
+
+  if (balloon === BALLOON_RICH_LINK) {
+    return resolveRichLink(rawPayload);
+  }
+  if (balloon === BALLOON_CHECKIN) {
+    return resolveCheckin(rawPayload);
+  }
+  if (balloon === BALLOON_LOCATION) {
+    return resolveLocationShare(rawPayload);
+  }
+  if (balloon === BALLOON_POLL) {
+    return { type: "poll", pollMessageGuid: messageGuid(proto.guid) };
+  }
+  if (balloon.startsWith(BALLOON_COLLAB_PREFIX)) {
+    return resolveCollaboration(balloon, rawPayload);
+  }
+  return undefined;
+}
+
+function resolveAttachment(
+  proto: ProtoMessage,
+  mappedAttachments: readonly AttachmentInfo[]
+): MessageContent | undefined {
+  const first = mappedAttachments[0];
+  if (!first) {
+    return undefined;
+  }
+
+  if (first.isSticker) {
+    return { type: "sticker", attachment: first };
+  }
+
+  const mime = first.mimeType.toLowerCase();
+
+  if (mime === "text/vcard" || mime === "text/x-vcard") {
+    return { type: "contact", attachmentGuid: first.guid };
+  }
+  if (mime.startsWith("image/")) {
+    return {
+      type: "image",
+      attachment: first,
+      height: first.height,
+      subtype: IMAGE_SUBTYPE_MAP[mime],
+      width: first.width,
+    };
+  }
+  if (mime.startsWith("video/")) {
+    return {
+      type: "video",
+      attachment: first,
+      height: first.height,
+      width: first.width,
+    };
+  }
+  if (mime.startsWith("audio/")) {
+    return {
+      type: "audio",
+      attachment: first,
+      isVoiceMessage: proto.isAudioMessage,
+    };
+  }
+  return { type: "file", attachment: first };
+}
+
+function tryDecompress(rawPayload: Uint8Array | undefined): Uint8Array | null {
+  if (!rawPayload || rawPayload.length === 0) {
+    return null;
+  }
+  return decompressPayload(rawPayload);
+}
+
+function resolveRichLink(rawPayload: Uint8Array | undefined): MessageContent {
+  const decompressed = tryDecompress(rawPayload);
+  if (!decompressed) {
+    return { type: "richLink", raw: rawPayload };
+  }
+  const extracted = extractRichLink(decompressed);
+  return {
+    type: "richLink",
+    url: extracted.url,
+    title: extracted.title,
+    summary: extracted.summary,
+    imageUrl: extracted.imageUrl,
+    raw: extracted.url ? undefined : rawPayload,
+  };
+}
+
+function resolveCheckin(rawPayload: Uint8Array | undefined): MessageContent {
+  const decompressed = tryDecompress(rawPayload);
+  if (!decompressed) {
+    return {
+      type: "checkin",
+      mode: "unknown",
+      status: "unknown",
+      raw: rawPayload,
+    };
+  }
+  const extracted = extractCheckin(decompressed);
+  return {
+    type: "checkin",
+    mode: extracted.mode,
+    status: extracted.status,
+    sessionId: extracted.sessionId,
+    estimatedEndTime: extracted.estimatedEndTime,
+    destinationName: extracted.destinationName,
+    raw:
+      extracted.mode === "unknown" && extracted.status === "unknown"
+        ? rawPayload
+        : undefined,
+  };
+}
+
+function resolveLocationShare(
+  rawPayload: Uint8Array | undefined
+): MessageContent {
+  const decompressed = tryDecompress(rawPayload);
+  if (!decompressed) {
+    return { type: "locationShare", kind: "unknown", raw: rawPayload };
+  }
+  const extracted = extractLocationShare(decompressed);
+  return {
+    type: "locationShare",
+    kind: extracted.kind,
+    coordinates:
+      extracted.latitude != null && extracted.longitude != null
+        ? { latitude: extracted.latitude, longitude: extracted.longitude }
+        : undefined,
+    address: extracted.address,
+    mapsUrl: extracted.mapsUrl,
+    raw: extracted.kind === "unknown" ? rawPayload : undefined,
+  };
+}
+
+function resolveCollaboration(
+  balloonBundleId: string,
+  rawPayload: Uint8Array | undefined
+): MessageContent {
+  const bundleId = balloonBundleId.slice(BALLOON_COLLAB_PREFIX.length);
+  const decompressed = tryDecompress(rawPayload);
+  if (!decompressed) {
+    return { type: "collaboration", bundleId, raw: rawPayload };
+  }
+  const extracted = extractCollaboration(decompressed);
+  return {
+    type: "collaboration",
+    appName: extracted.appName,
+    url: extracted.url,
+    bundleId,
+    raw: extracted.appName || extracted.url ? undefined : rawPayload,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Domain type mappers: proto -> SDK (continued)
+// ---------------------------------------------------------------------------
+
 /**
  * Map a proto `Message` to the SDK `Message`.
  *
@@ -252,11 +555,14 @@ export function mapAttachmentInfo(proto: ProtoAttachmentInfo): AttachmentInfo {
  * object.
  */
 export function mapMessage(proto: ProtoMessage): Message {
+  const mappedAttachments = proto.attachments.map(mapAttachmentInfo);
+
   return {
     guid: messageGuid(proto.guid),
     clientMessageId: proto.clientMessageId,
 
     // Content
+    content: resolveContent(proto, mappedAttachments),
     text: proto.text,
     subject: proto.subject,
 
@@ -295,8 +601,14 @@ export function mapMessage(proto: ProtoMessage): Message {
     expressiveSendStyleId: proto.expressiveSendStyleId,
 
     // Relations
-    attachments: proto.attachments.map(mapAttachmentInfo),
+    attachments: mappedAttachments,
     chatGuids: proto.chatGuids.map(chatGuid),
+
+    // Threading
+    threadOriginatorGuid: proto.threadOriginatorGuid
+      ? messageGuid(proto.threadOriginatorGuid)
+      : undefined,
+    threadOriginatorPart: proto.threadOriginatorPart,
 
     // Runtime
     latencyMs: proto.latencyMs,

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -12,6 +12,7 @@ import type { AttachmentInfo } from "./attachments.js";
 import type { AttachmentGuid, ChatGuid, MessageGuid } from "./branded.js";
 import type { MessageEffect, TextEffect } from "./effects.js";
 import type { MessageItemType, SortDirection } from "./enums.js";
+import type { Reaction } from "./reactions.js";
 
 // ---------------------------------------------------------------------------
 // Message
@@ -36,6 +37,11 @@ export interface Message {
   readonly chatGuids: readonly ChatGuid[];
   /** Client-provided idempotency key, if one was supplied when sending. */
   readonly clientMessageId?: string;
+
+  // -- Content ---------------------------------------------------------------
+
+  /** Structured interpretation of the message (text, image, reaction, etc.). */
+  readonly content: MessageContent;
 
   // -- Timeline --------------------------------------------------------------
 
@@ -99,11 +105,199 @@ export interface Message {
   readonly sender?: AddressInfo;
   /** Subject line (used with MMS-style messages). */
   readonly subject?: string;
-
-  // -- Content ---------------------------------------------------------------
-
   /** Plain-text body of the message. */
   readonly text?: string;
+
+  // -- Threading -------------------------------------------------------------
+
+  /** GUID of the thread originator message, when this is a threaded reply. */
+  readonly threadOriginatorGuid?: MessageGuid;
+  /** Part index on the originator message this reply targets. */
+  readonly threadOriginatorPart?: string;
+}
+
+// ---------------------------------------------------------------------------
+// MessageContent
+// ---------------------------------------------------------------------------
+
+export interface TextContent {
+  readonly effect?: string;
+  readonly text: string;
+  readonly type: "text";
+}
+
+export interface ImageContent {
+  readonly attachment: AttachmentInfo;
+  readonly height?: number;
+  readonly subtype?: "gif" | "png" | "heic" | "jpeg" | "webp";
+  readonly type: "image";
+  readonly width?: number;
+}
+
+export interface VideoContent {
+  readonly attachment: AttachmentInfo;
+  readonly height?: number;
+  readonly type: "video";
+  readonly width?: number;
+}
+
+export interface AudioContent {
+  readonly attachment: AttachmentInfo;
+  readonly isVoiceMessage: boolean;
+  readonly type: "audio";
+}
+
+export interface FileContent {
+  readonly attachment: AttachmentInfo;
+  readonly type: "file";
+}
+
+export interface ReactionContent {
+  readonly emoji?: string;
+  readonly isRemoval: boolean;
+  readonly reaction: Reaction;
+  readonly targetGuid: MessageGuid;
+  readonly targetPart: number;
+  readonly type: "reaction";
+}
+
+export interface EditContent {
+  readonly editedAt: Date;
+  readonly newText: string;
+  readonly originalText?: string;
+  readonly type: "edit";
+}
+
+export interface UnsendContent {
+  readonly retractedAt: Date;
+  readonly type: "unsend";
+}
+
+export interface ContactContent {
+  readonly attachmentGuid?: AttachmentGuid;
+  readonly type: "contact";
+}
+
+export interface RichLinkContent {
+  readonly imageUrl?: string;
+  readonly raw?: Uint8Array;
+  readonly summary?: string;
+  readonly title?: string;
+  readonly type: "richLink";
+  readonly url?: string;
+}
+
+export interface LocationShareContent {
+  readonly address?: string;
+  readonly coordinates?: {
+    readonly latitude: number;
+    readonly longitude: number;
+  };
+  readonly kind: "pin" | "live" | "mapsLink" | "unknown";
+  readonly mapsUrl?: string;
+  readonly raw?: Uint8Array;
+  readonly type: "locationShare";
+}
+
+export interface CheckinContent {
+  readonly destinationName?: string;
+  readonly estimatedEndTime?: Date;
+  readonly mode: "timer" | "travel" | "unknown";
+  readonly raw?: Uint8Array;
+  readonly sessionId?: string;
+  readonly status: "started" | "stopped" | "expired" | "checkedIn" | "unknown";
+  readonly type: "checkin";
+}
+
+export interface PollContent {
+  readonly pollMessageGuid: MessageGuid;
+  readonly type: "poll";
+}
+
+export interface StickerContent {
+  readonly attachment: AttachmentInfo;
+  readonly type: "sticker";
+}
+
+export interface CollaborationContent {
+  readonly appName?: string;
+  readonly bundleId: string;
+  readonly raw?: Uint8Array;
+  readonly type: "collaboration";
+  readonly url?: string;
+}
+
+export interface SystemContent {
+  readonly groupTitle?: string;
+  readonly systemType: Exclude<MessageItemType, "normal"> | "other";
+  readonly type: "system";
+}
+
+export interface UnknownContent {
+  readonly type: "unknown";
+}
+
+export type MessageContent =
+  | AudioContent
+  | CheckinContent
+  | CollaborationContent
+  | ContactContent
+  | EditContent
+  | FileContent
+  | ImageContent
+  | LocationShareContent
+  | PollContent
+  | ReactionContent
+  | RichLinkContent
+  | StickerContent
+  | SystemContent
+  | TextContent
+  | UnknownContent
+  | UnsendContent
+  | VideoContent;
+
+// ---------------------------------------------------------------------------
+// VCard types
+// ---------------------------------------------------------------------------
+
+export interface VCardPhoto {
+  /** Base64-encoded image data. */
+  readonly data: string;
+  /** MIME type (e.g. "image/jpeg"). */
+  readonly mimeType: string;
+}
+
+export interface VCardAddress {
+  readonly city?: string;
+  readonly country?: string;
+  readonly label?: string;
+  readonly postalCode?: string;
+  readonly state?: string;
+  readonly street?: string;
+}
+
+export interface VCardContact {
+  readonly addresses: readonly VCardAddress[];
+  readonly emails: readonly VCardEmail[];
+  readonly firstName?: string;
+  readonly fullName?: string;
+  readonly lastName?: string;
+  readonly note?: string;
+  readonly org?: string;
+  readonly phones: readonly VCardPhone[];
+  readonly photo?: VCardPhoto;
+  readonly title?: string;
+  readonly urls: readonly string[];
+}
+
+export interface VCardPhone {
+  readonly label?: string;
+  readonly value: string;
+}
+
+export interface VCardEmail {
+  readonly label?: string;
+  readonly value: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -1,0 +1,459 @@
+/**
+ * Decoders for Apple iMessage binary payloads and vCard contacts.
+ */
+
+import { inflateSync } from "node:zlib";
+
+import type {
+  VCardAddress,
+  VCardContact,
+  VCardEmail,
+  VCardPhone,
+  VCardPhoto,
+} from "../types/messages.js";
+
+// ---------------------------------------------------------------------------
+// Payload decompression + balloon decoders
+// ---------------------------------------------------------------------------
+
+export function decompressPayload(data: Uint8Array): Uint8Array | null {
+  try {
+    return inflateSync(data);
+  } catch {
+    return null;
+  }
+}
+
+interface RichLinkPayload {
+  imageUrl?: string;
+  summary?: string;
+  title?: string;
+  url?: string;
+}
+
+export function extractRichLink(data: Uint8Array): RichLinkPayload {
+  const text = safeDecodeUtf8(data);
+  return {
+    url: extractFirstUrl(text),
+    title:
+      extractPlistString(text, "LPLinkMetadataTitleKey") ??
+      extractPlistString(text, "title"),
+    summary:
+      extractPlistString(text, "LPLinkMetadataSummaryKey") ??
+      extractPlistString(text, "summary"),
+    imageUrl:
+      extractPlistString(text, "LPLinkMetadataImageURLKey") ??
+      extractSecondaryUrl(text),
+  };
+}
+
+interface LocationSharePayload {
+  address?: string;
+  kind: "pin" | "live" | "mapsLink" | "unknown";
+  latitude?: number;
+  longitude?: number;
+  mapsUrl?: string;
+}
+
+export function extractLocationShare(data: Uint8Array): LocationSharePayload {
+  const text = safeDecodeUtf8(data);
+  const mapsUrl = extractMapsUrl(text);
+  const coords = extractCoordinates(text);
+
+  let kind: LocationSharePayload["kind"] = "unknown";
+  if (text.includes("live")) {
+    kind = "live";
+  } else if (coords) {
+    kind = "pin";
+  } else if (mapsUrl) {
+    kind = "mapsLink";
+  }
+
+  return {
+    kind,
+    latitude: coords?.latitude,
+    longitude: coords?.longitude,
+    address:
+      extractPlistString(text, "address") ??
+      extractPlistString(text, "formattedAddress"),
+    mapsUrl,
+  };
+}
+
+interface CheckinPayload {
+  destinationName?: string;
+  estimatedEndTime?: Date;
+  mode: "timer" | "travel" | "unknown";
+  sessionId?: string;
+  status: "started" | "stopped" | "expired" | "checkedIn" | "unknown";
+}
+
+export function extractCheckin(data: Uint8Array): CheckinPayload {
+  const text = safeDecodeUtf8(data);
+
+  let mode: CheckinPayload["mode"] = "unknown";
+  if (text.includes("timer") || text.includes("Timer")) {
+    mode = "timer";
+  } else if (
+    text.includes("travel") ||
+    text.includes("Travel") ||
+    text.includes("destination")
+  ) {
+    mode = "travel";
+  }
+
+  let status: CheckinPayload["status"] = "unknown";
+  if (text.includes("started") || text.includes("Started")) {
+    status = "started";
+  } else if (text.includes("stopped") || text.includes("Stopped")) {
+    status = "stopped";
+  } else if (text.includes("expired") || text.includes("Expired")) {
+    status = "expired";
+  } else if (
+    text.includes("checkedIn") ||
+    text.includes("CheckedIn") ||
+    text.includes("checked in")
+  ) {
+    status = "checkedIn";
+  }
+
+  return {
+    mode,
+    status,
+    sessionId:
+      extractPlistString(text, "sessionID") ??
+      extractPlistString(text, "sessionId"),
+    estimatedEndTime: extractTimestamp(text, "estimatedEndTime"),
+    destinationName:
+      extractPlistString(text, "destinationName") ??
+      extractPlistString(text, "destination"),
+  };
+}
+
+interface CollaborationPayload {
+  appName?: string;
+  url?: string;
+}
+
+export function extractCollaboration(data: Uint8Array): CollaborationPayload {
+  const text = safeDecodeUtf8(data);
+  return {
+    appName:
+      extractPlistString(text, "appName") ??
+      extractPlistString(text, "applicationName") ??
+      extractPlistString(text, "senderDisplayName"),
+    url: extractFirstUrl(text),
+  };
+}
+
+/** Edit history is binary; decompress and search for readable text. */
+export function extractOriginalText(
+  summaryInfo: Uint8Array
+): string | undefined {
+  const decompressed = decompressPayload(summaryInfo);
+  const bytes = decompressed ?? summaryInfo;
+  const text = safeDecodeUtf8(bytes);
+
+  const readable = text.replace(NON_PRINTABLE_RE, " ").trim();
+  const segments = readable.split(MULTI_SPACE_RE).filter((s) => s.length > 1);
+
+  return segments.length > 0 ? segments[0] : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Plist internal helpers
+// ---------------------------------------------------------------------------
+
+const NON_PRINTABLE_RE = /[^\x20-\x7E\n\r\t]/g;
+const MULTI_SPACE_RE = /\s{2,}/;
+const MAPS_URL_RE = /https?:\/\/maps\.apple\.com[^\s"'<>)\]},;]*/;
+const PLIST_VALUE_RE = /^\s*(.{2,200}?)(?:\s{2,}|$)/;
+const NON_PRINTABLE_CLEAN_RE = /[^\x20-\x7E]/g;
+const EPOCH_RE = /(\d{10,13})/;
+
+function safeDecodeUtf8(data: Uint8Array): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: false }).decode(data);
+  } catch {
+    return "";
+  }
+}
+
+const URL_RE = /https?:\/\/[^\s"'<>)\]},;]+/g;
+
+function extractFirstUrl(text: string): string | undefined {
+  const match = URL_RE.exec(text);
+  URL_RE.lastIndex = 0;
+  return match?.[0];
+}
+
+function extractSecondaryUrl(text: string): string | undefined {
+  const matches = text.match(URL_RE);
+  return matches && matches.length > 1 ? matches[1] : undefined;
+}
+
+function extractMapsUrl(text: string): string | undefined {
+  const match = text.match(MAPS_URL_RE);
+  return match?.[0] ?? extractFirstUrl(text);
+}
+
+/** NSKeyedArchiver lays out keys and values in proximity. */
+function extractPlistString(text: string, key: string): string | undefined {
+  const keyIdx = text.indexOf(key);
+  if (keyIdx === -1) {
+    return undefined;
+  }
+
+  const after = text.slice(keyIdx + key.length, keyIdx + key.length + 500);
+  const cleaned = after.replace(NON_PRINTABLE_CLEAN_RE, " ").trim();
+
+  const match = cleaned.match(PLIST_VALUE_RE);
+  return match?.[1]?.trim() || undefined;
+}
+
+const COORD_RE = /[-+]?\d{1,3}\.\d{4,}/g;
+
+function extractCoordinates(
+  text: string
+): { latitude: number; longitude: number } | undefined {
+  const matches = text.match(COORD_RE);
+  if (!matches || matches.length < 2) {
+    return undefined;
+  }
+
+  const lat = Number.parseFloat(matches[0] ?? "");
+  const lng = Number.parseFloat(matches[1] ?? "");
+  if (Number.isNaN(lat) || Number.isNaN(lng)) {
+    return undefined;
+  }
+  if (Math.abs(lat) > 90 || Math.abs(lng) > 180) {
+    return undefined;
+  }
+
+  return { latitude: lat, longitude: lng };
+}
+
+function extractTimestamp(text: string, key: string): Date | undefined {
+  const keyIdx = text.indexOf(key);
+  if (keyIdx === -1) {
+    return undefined;
+  }
+
+  const after = text.slice(keyIdx + key.length, keyIdx + key.length + 100);
+  const epochMatch = after.match(EPOCH_RE);
+  if (!epochMatch) {
+    return undefined;
+  }
+
+  const epoch = Number.parseInt(epochMatch[1] ?? "", 10);
+  if (Number.isNaN(epoch)) {
+    return undefined;
+  }
+
+  const ms = epoch > 1e12 ? epoch : epoch * 1000;
+  const date = new Date(ms);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+// ---------------------------------------------------------------------------
+// vCard parser
+// ---------------------------------------------------------------------------
+
+const VCARD_FOLD_RE = /\r?\n[ \t]/g;
+const VCARD_NEWLINE_RE = /\r?\n/;
+const TEL_CLEAN_RE = /[^\d+\-() ]/g;
+const LABEL_PREFIX_RE = /^x-/i;
+
+interface VCardState {
+  addresses: VCardAddress[];
+  emails: VCardEmail[];
+  firstName: string | undefined;
+  fullName: string | undefined;
+  lastName: string | undefined;
+  note: string | undefined;
+  org: string | undefined;
+  phones: VCardPhone[];
+  photo: VCardPhoto | undefined;
+  title: string | undefined;
+  urls: string[];
+}
+
+export function parseVCard(data: string | Uint8Array): VCardContact {
+  const text = typeof data === "string" ? data : new TextDecoder().decode(data);
+  const unfolded = text.replace(VCARD_FOLD_RE, "");
+  const lines = unfolded.split(VCARD_NEWLINE_RE);
+
+  const state: VCardState = {
+    addresses: [],
+    emails: [],
+    firstName: undefined,
+    fullName: undefined,
+    lastName: undefined,
+    note: undefined,
+    org: undefined,
+    phones: [],
+    photo: undefined,
+    title: undefined,
+    urls: [],
+  };
+
+  for (const line of lines) {
+    processVCardLine(line, state);
+  }
+
+  return {
+    addresses: state.addresses,
+    emails: state.emails,
+    firstName: state.firstName,
+    fullName: state.fullName,
+    lastName: state.lastName,
+    note: state.note,
+    org: state.org,
+    phones: state.phones,
+    photo: state.photo,
+    title: state.title,
+    urls: state.urls,
+  };
+}
+
+function processVCardLine(line: string, state: VCardState): void {
+  const colonIdx = line.indexOf(":");
+  if (colonIdx === -1) {
+    return;
+  }
+
+  const keyPart = line.slice(0, colonIdx);
+  const value = line.slice(colonIdx + 1).trim();
+  if (!value) {
+    return;
+  }
+
+  const { name, params } = parseVCardProperty(keyPart);
+
+  switch (name.toUpperCase()) {
+    case "FN":
+      state.fullName = decodeVCardValue(value, params);
+      break;
+    case "N": {
+      const parts = value.split(";");
+      state.lastName = parts[0]
+        ? decodeVCardValue(parts[0], params)
+        : undefined;
+      state.firstName = parts[1]
+        ? decodeVCardValue(parts[1], params)
+        : undefined;
+      break;
+    }
+    case "ORG":
+      state.org = decodeVCardValue(value.split(";")[0] ?? "", params);
+      break;
+    case "TITLE":
+      state.title = decodeVCardValue(value, params);
+      break;
+    case "TEL":
+      state.phones.push({
+        label: extractVCardLabel(params),
+        value: value.replace(TEL_CLEAN_RE, ""),
+      });
+      break;
+    case "EMAIL":
+      state.emails.push({ label: extractVCardLabel(params), value });
+      break;
+    case "ADR": {
+      const parts = value.split(";");
+      state.addresses.push({
+        city: parts[3] || undefined,
+        country: parts[6] || undefined,
+        label: extractVCardLabel(params),
+        postalCode: parts[5] || undefined,
+        state: parts[4] || undefined,
+        street: parts[2] || undefined,
+      });
+      break;
+    }
+    case "PHOTO": {
+      const mimeType = extractPhotoMime(params);
+      if (mimeType) {
+        state.photo = { data: value, mimeType };
+      }
+      break;
+    }
+    case "NOTE":
+      state.note = decodeVCardValue(value, params);
+      break;
+    case "URL":
+      state.urls.push(value);
+      break;
+    default:
+      break;
+  }
+}
+
+interface VCardPropertyParts {
+  name: string;
+  params: Map<string, string>;
+}
+
+function parseVCardProperty(keyPart: string): VCardPropertyParts {
+  const segments = keyPart.split(";");
+  const name = segments[0] ?? "";
+  const params = new Map<string, string>();
+  for (let i = 1; i < segments.length; i++) {
+    const seg = segments[i] ?? "";
+    const eqIdx = seg.indexOf("=");
+    if (eqIdx === -1) {
+      params.set(seg.toUpperCase(), "");
+    } else {
+      params.set(seg.slice(0, eqIdx).toUpperCase(), seg.slice(eqIdx + 1));
+    }
+  }
+  return { name, params };
+}
+
+function extractVCardLabel(params: Map<string, string>): string | undefined {
+  const typeVal = params.get("TYPE");
+  if (!typeVal) {
+    return undefined;
+  }
+  const label = typeVal.split(",")[0];
+  return label ? label.replace(LABEL_PREFIX_RE, "").toLowerCase() : undefined;
+}
+
+function extractPhotoMime(params: Map<string, string>): string | undefined {
+  const mediatype = params.get("MEDIATYPE");
+  if (mediatype) {
+    return mediatype;
+  }
+  const type = params.get("TYPE");
+  if (type) {
+    const lower = type.toLowerCase();
+    if (lower === "jpeg" || lower === "jpg") {
+      return "image/jpeg";
+    }
+    if (lower === "png") {
+      return "image/png";
+    }
+    if (lower === "gif") {
+      return "image/gif";
+    }
+    if (lower.startsWith("image/")) {
+      return lower;
+    }
+  }
+  const encoding = params.get("ENCODING");
+  if (encoding?.toUpperCase() === "B" || encoding?.toUpperCase() === "BASE64") {
+    return "image/jpeg";
+  }
+  return undefined;
+}
+
+function decodeVCardValue(value: string, params: Map<string, string>): string {
+  const charset = params.get("CHARSET")?.toUpperCase();
+  if (charset === "UTF-8" || !charset) {
+    return value
+      .replace(/\\n/g, "\n")
+      .replace(/\\,/g, ",")
+      .replace(/\\\\/g, "\\");
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

- Every `Message` now carries a `content: MessageContent` discriminated union (17 variants) computed at map time, giving typed access to text, images, reactions, rich links, check-ins, location shares, edits, unsends, contacts, polls, stickers, collaborations, and system messages
- Balloon payloads (rich links, check-ins, location shares, collaborations) are zlib-decompressed and parsed from Apple's NSKeyedArchiver format in `src/utils/payload.ts`
- Exports `parseVCard()` utility for consumers to decode contact card attachments after download

## Changes

| File | What changed |
|------|-------------|
| `src/types/messages.ts` | Added 17 content interfaces, `MessageContent` union, VCard types |
| `src/transport/mapper.ts` | Added `resolveContent()` and helpers for content resolution |
| `src/utils/payload.ts` | New file -- balloon payload decoders + vCard parser |
| `src/index.ts` | Consolidated exports via `export *` from messages |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `bun x ultracite check` passes
- [x] `bun test` -- 24/24 tests pass
- [ ] Verify in spectrum-ts that `message.content` narrows correctly in switch statements
- [ ] Test with real rich link / check-in / location share messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages now include strongly-typed `content` field supporting multiple types (text, images, videos, reactions, edits, unsends, contacts, locations, polls, and more).
  * Added message threading support with originator tracking.
  * Added vCard contact parsing functionality to the public API.

* **API Changes**
  * Expanded message type exports for improved library access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->