### PR TITLE
fix: sync message service SDK with server proto

### DIFF
--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -161,6 +161,7 @@ message StickerPlacement {
   double y = 2;
   optional double scale = 3;
   optional double rotation = 4;
+  optional double width = 5;
 }
 
 message MessagePart {
@@ -198,7 +199,8 @@ message SendRequest {
   repeated MessagePart parts = 15;
   optional string selected_message_guid = 16;
   int32 part_index = 17;
-  optional string service = 18;
+  reserved 18;
+  reserved "service";
   repeated TextFormat formatting = 19;
 }
 

--- a/src/builders/message-builder.ts
+++ b/src/builders/message-builder.ts
@@ -22,7 +22,6 @@ export class MessageBuilder {
   private _effect?: MessageEffect;
   private _subject?: string;
   private _replyTo?: MessageGuid | { guid: MessageGuid; partIndex?: number };
-  private _service?: "iMessage" | "SMS" | "RCS";
 
   // ---------------------------------------------------------------------------
   // Static factories
@@ -190,12 +189,6 @@ export class MessageBuilder {
     return this;
   }
 
-  /** Force the message to be sent via a specific transport. */
-  withService(service: "iMessage" | "SMS" | "RCS"): this {
-    this._service = service;
-    return this;
-  }
-
   // ---------------------------------------------------------------------------
   // Terminal
   // ---------------------------------------------------------------------------
@@ -218,7 +211,6 @@ export class MessageBuilder {
       ...(this._effect != null && { effect: this._effect }),
       ...(this._subject != null && { subject: this._subject }),
       ...(this._replyTo != null && { replyTo: this._replyTo }),
-      ...(this._service != null && { service: this._service }),
     };
 
     return message;

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -235,6 +235,7 @@ export interface StickerPlacement {
   y: number;
   scale?: number | undefined;
   rotation?: number | undefined;
+  width?: number | undefined;
 }
 
 export interface MessagePart {
@@ -271,7 +272,6 @@ export interface SendRequest {
   parts: MessagePart[];
   selectedMessageGuid?: string | undefined;
   partIndex: number;
-  service?: string | undefined;
   formatting: TextFormat[];
 }
 
@@ -2071,7 +2071,7 @@ export const Message: MessageFns<Message> = {
 };
 
 function createBaseStickerPlacement(): StickerPlacement {
-  return { x: 0, y: 0, scale: undefined, rotation: undefined };
+  return { x: 0, y: 0, scale: undefined, rotation: undefined, width: undefined };
 }
 
 export const StickerPlacement: MessageFns<StickerPlacement> = {
@@ -2087,6 +2087,9 @@ export const StickerPlacement: MessageFns<StickerPlacement> = {
     }
     if (message.rotation !== undefined) {
       writer.uint32(33).double(message.rotation);
+    }
+    if (message.width !== undefined) {
+      writer.uint32(41).double(message.width);
     }
     return writer;
   },
@@ -2130,6 +2133,14 @@ export const StickerPlacement: MessageFns<StickerPlacement> = {
           message.rotation = reader.double();
           continue;
         }
+        case 5: {
+          if (tag !== 41) {
+            break;
+          }
+
+          message.width = reader.double();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2145,6 +2156,7 @@ export const StickerPlacement: MessageFns<StickerPlacement> = {
       y: isSet(object.y) ? globalThis.Number(object.y) : 0,
       scale: isSet(object.scale) ? globalThis.Number(object.scale) : undefined,
       rotation: isSet(object.rotation) ? globalThis.Number(object.rotation) : undefined,
+      width: isSet(object.width) ? globalThis.Number(object.width) : undefined,
     };
   },
 
@@ -2162,6 +2174,9 @@ export const StickerPlacement: MessageFns<StickerPlacement> = {
     if (message.rotation !== undefined) {
       obj.rotation = message.rotation;
     }
+    if (message.width !== undefined) {
+      obj.width = message.width;
+    }
     return obj;
   },
 
@@ -2174,6 +2189,7 @@ export const StickerPlacement: MessageFns<StickerPlacement> = {
     message.y = object.y ?? 0;
     message.scale = object.scale ?? undefined;
     message.rotation = object.rotation ?? undefined;
+    message.width = object.width ?? undefined;
     return message;
   },
 };
@@ -2470,7 +2486,6 @@ function createBaseSendRequest(): SendRequest {
     parts: [],
     selectedMessageGuid: undefined,
     partIndex: 0,
-    service: undefined,
     formatting: [],
   };
 }
@@ -2527,9 +2542,6 @@ export const SendRequest: MessageFns<SendRequest> = {
     }
     if (message.partIndex !== 0) {
       writer.uint32(136).int32(message.partIndex);
-    }
-    if (message.service !== undefined) {
-      writer.uint32(146).string(message.service);
     }
     for (const v of message.formatting) {
       TextFormat.encode(v!, writer.uint32(154).fork()).join();
@@ -2680,14 +2692,6 @@ export const SendRequest: MessageFns<SendRequest> = {
           message.partIndex = reader.int32();
           continue;
         }
-        case 18: {
-          if (tag !== 146) {
-            break;
-          }
-
-          message.service = reader.string();
-          continue;
-        }
         case 19: {
           if (tag !== 154) {
             break;
@@ -2782,7 +2786,6 @@ export const SendRequest: MessageFns<SendRequest> = {
         : isSet(object.part_index)
         ? globalThis.Number(object.part_index)
         : 0,
-      service: isSet(object.service) ? globalThis.String(object.service) : undefined,
       formatting: globalThis.Array.isArray(object?.formatting)
         ? object.formatting.map((e: any) => TextFormat.fromJSON(e))
         : [],
@@ -2842,9 +2845,6 @@ export const SendRequest: MessageFns<SendRequest> = {
     if (message.partIndex !== 0) {
       obj.partIndex = Math.round(message.partIndex);
     }
-    if (message.service !== undefined) {
-      obj.service = message.service;
-    }
     if (message.formatting?.length) {
       obj.formatting = message.formatting.map((e) => TextFormat.toJSON(e));
     }
@@ -2875,7 +2875,6 @@ export const SendRequest: MessageFns<SendRequest> = {
     message.parts = object.parts?.map((e) => MessagePart.fromPartial(e)) || [];
     message.selectedMessageGuid = object.selectedMessageGuid ?? undefined;
     message.partIndex = object.partIndex ?? 0;
-    message.service = object.service ?? undefined;
     message.formatting = object.formatting?.map((e) => TextFormat.fromPartial(e)) || [];
     return message;
   },

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -180,13 +180,13 @@ export class MessagesResource {
             y: options.sticker.placement.y,
             scale: options.sticker.placement.scale,
             rotation: options.sticker.placement.rotation,
+            width: options.sticker.placement.width,
           } satisfies ProtoStickerPlacement)
         : undefined,
       selectedMessageGuid:
         reply?.selectedMessageGuid ??
         (options?.sticker?.target as string | undefined),
       partIndex: reply?.partIndex ?? 0,
-      service: options?.service,
       parts: [],
       formatting: toProtoFormatting(options?.formatting),
     };
@@ -243,13 +243,13 @@ export class MessagesResource {
             y: options.sticker.placement.y,
             scale: options.sticker.placement.scale,
             rotation: options.sticker.placement.rotation,
+            width: options.sticker.placement.width,
           } satisfies ProtoStickerPlacement)
         : undefined,
       selectedMessageGuid:
         reply?.selectedMessageGuid ??
         (options?.sticker?.target as string | undefined),
       partIndex: reply?.partIndex ?? 0,
-      service: options?.service,
       parts: toProtoMessageParts(parts),
       formatting: [],
     };
@@ -291,7 +291,6 @@ export class MessagesResource {
       isSticker: false,
       selectedMessageGuid: reply?.selectedMessageGuid,
       partIndex: reply?.partIndex ?? 0,
-      service: message.service,
       parts: toProtoMessageParts(message.parts),
       formatting: [],
     };

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -153,6 +153,7 @@ export type TextFormatInput =
 export interface StickerPlacement {
   readonly rotation?: number;
   readonly scale?: number;
+  readonly width?: number;
   readonly x: number;
   readonly y: number;
 }
@@ -181,8 +182,6 @@ export interface SendOptions {
     | { readonly guid: MessageGuid; readonly partIndex?: number };
   /** Enable rich link previews. */
   readonly richLink?: boolean;
-  /** Force a specific transport service. */
-  readonly service?: "iMessage" | "SMS" | "RCS";
   /** Place a sticker on an existing message. */
   readonly sticker?: {
     readonly attachment: AttachmentGuid;
@@ -230,8 +229,6 @@ export interface ComposedMessage {
   readonly replyTo?:
     | MessageGuid
     | { readonly guid: MessageGuid; readonly partIndex?: number };
-  /** Force a specific transport service. */
-  readonly service?: "iMessage" | "SMS" | "RCS";
   /** Subject line. */
   readonly subject?: string;
 }

--- a/tests/unit/messages-resource.test.ts
+++ b/tests/unit/messages-resource.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { MessagesResource } from "../../src/resources/messages.ts";
+import type {
+  AttachmentGuid,
+  ChatGuid,
+  MessageGuid,
+} from "../../src/types/branded.ts";
+
+const chatGuidValue = "iMessage;-;alice@icloud.com" as ChatGuid;
+const attachmentGuidValue = "attachment-1" as AttachmentGuid;
+const messageGuidValue = "message-1" as MessageGuid;
+
+describe("MessagesResource sticker placement", () => {
+  it("includes sticker width when sending a sticker", async () => {
+    let capturedRequest: Record<string, unknown> | undefined;
+    const resource = new MessagesResource({
+      async send(request: Record<string, unknown>) {
+        capturedRequest = request;
+        return {
+          receipt: {
+            guid: "sent-1",
+          },
+        };
+      },
+    } as any);
+
+    await resource.send(chatGuidValue, "", {
+      sticker: {
+        attachment: attachmentGuidValue,
+        target: messageGuidValue,
+        placement: {
+          x: 10,
+          y: 20,
+          width: 80,
+        },
+      },
+    });
+
+    expect(capturedRequest?.stickerPlacement).toEqual({
+      x: 10,
+      y: 20,
+      scale: undefined,
+      rotation: undefined,
+      width: 80,
+    });
+  });
+
+  it("does not forward a removed send service override", async () => {
+    let capturedRequest: Record<string, unknown> | undefined;
+    const resource = new MessagesResource({
+      async send(request: Record<string, unknown>) {
+        capturedRequest = request;
+        return {
+          receipt: {
+            guid: "sent-2",
+          },
+        };
+      },
+    } as any);
+
+    await resource.send(chatGuidValue, "hello", {
+      // Runtime callers can still pass extra properties even after the public
+      // type is removed; verify we do not send the stale wire field.
+      ...({ service: "SMS" } as any),
+    });
+
+    expect("service" in (capturedRequest ?? {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR aligns the SDK's message service contract with the current server proto.

It intentionally excludes the location-service changes so they can ship in a
separate PR.

## What Changed

- synced `message_service.proto` with the server contract
- regenerated the TypeScript message-service client/types from the updated proto
- added `StickerPlacement.width` support to the public SDK types and request mapping
- removed the stale `SendRequest.service` wire field from the SDK request path
- removed the corresponding message-level service override from the public API
  and `MessageBuilder`
- added tests covering sticker-width request serialization and ensuring the
  removed `service` field is not sent

## Why

The SDK had drifted from the server's message-service contract.

In particular:

- the server now supports `StickerPlacement.width`, but the SDK could not send it
- the SDK still exposed and attempted to send `SendRequest.service`, even though
  the server proto now reserves that field

Keeping the handwritten SDK layer aligned with the regenerated proto avoids
type/runtime mismatches and prevents the public API from advertising a message
sending capability the server no longer supports.

## Scope

- includes only message-service alignment work
- excludes location-service changes on purpose

## Testing

- `bun run check`
- `bun test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sticker placement now supports a `width` parameter to control sticker sizing.

* **Breaking Changes**
  * Removed message-level transport service selection; the ability to specify iMessage, SMS, or RCS routing per message is no longer supported.

* **Tests**
  * Added unit tests validating sticker placement properties and request payload format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->