### PR TITLE
fix: sync location service SDK with server proto

### DIFF
--- a/proto/photon/imessage/v1/location_service.proto
+++ b/proto/photon/imessage/v1/location_service.proto
@@ -10,8 +10,11 @@ import "google/protobuf/timestamp.proto";
 // ---------------------------------------------------------------------------
 
 service LocationService {
+  // Returns the current cached snapshot and triggers a background refresh.
   rpc GetFriends(GetFriendsRequest) returns (GetFriendsResponse);
-  rpc RefreshFriends(RefreshFriendsRequest) returns (RefreshFriendsResponse);
+
+  // Forwards real helper push events. While at least one subscriber is active,
+  // the server triggers periodic background refreshes.
   rpc SubscribeLocationEvents(SubscribeLocationEventsRequest) returns (stream SubscribeLocationEventsResponse);
 }
 
@@ -23,6 +26,7 @@ enum FindMyLocationType {
   FIND_MY_LOCATION_TYPE_UNSPECIFIED = 0;
   FIND_MY_LOCATION_TYPE_LIVE = 1;
   FIND_MY_LOCATION_TYPE_SHALLOW = 2;
+  FIND_MY_LOCATION_TYPE_LEGACY = 3;
 }
 
 message FindMyFriend {
@@ -43,15 +47,12 @@ message FindMyFriend {
 // Request / Response messages
 // ---------------------------------------------------------------------------
 
-message GetFriendsRequest {}
-
-message GetFriendsResponse {
-  repeated FindMyFriend friends = 1;
+message GetFriendsRequest {
+  // Filter by specific friend IDs. Empty = return all friends.
+  repeated string friend_ids = 1;
 }
 
-message RefreshFriendsRequest {}
-
-message RefreshFriendsResponse {
+message GetFriendsResponse {
   repeated FindMyFriend friends = 1;
 }
 

--- a/src/generated/photon/imessage/v1/location_service.ts
+++ b/src/generated/photon/imessage/v1/location_service.ts
@@ -15,6 +15,7 @@ export enum FindMyLocationType {
   FIND_MY_LOCATION_TYPE_UNSPECIFIED = 0,
   FIND_MY_LOCATION_TYPE_LIVE = 1,
   FIND_MY_LOCATION_TYPE_SHALLOW = 2,
+  FIND_MY_LOCATION_TYPE_LEGACY = 3,
   UNRECOGNIZED = -1,
 }
 
@@ -29,6 +30,9 @@ export function findMyLocationTypeFromJSON(object: any): FindMyLocationType {
     case 2:
     case "FIND_MY_LOCATION_TYPE_SHALLOW":
       return FindMyLocationType.FIND_MY_LOCATION_TYPE_SHALLOW;
+    case 3:
+    case "FIND_MY_LOCATION_TYPE_LEGACY":
+      return FindMyLocationType.FIND_MY_LOCATION_TYPE_LEGACY;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -44,6 +48,8 @@ export function findMyLocationTypeToJSON(object: FindMyLocationType): string {
       return "FIND_MY_LOCATION_TYPE_LIVE";
     case FindMyLocationType.FIND_MY_LOCATION_TYPE_SHALLOW:
       return "FIND_MY_LOCATION_TYPE_SHALLOW";
+    case FindMyLocationType.FIND_MY_LOCATION_TYPE_LEGACY:
+      return "FIND_MY_LOCATION_TYPE_LEGACY";
     case FindMyLocationType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";
@@ -65,16 +71,11 @@ export interface FindMyFriend {
 }
 
 export interface GetFriendsRequest {
+  /** Filter by specific friend IDs. Empty = return all friends. */
+  friendIds: string[];
 }
 
 export interface GetFriendsResponse {
-  friends: FindMyFriend[];
-}
-
-export interface RefreshFriendsRequest {
-}
-
-export interface RefreshFriendsResponse {
   friends: FindMyFriend[];
 }
 
@@ -347,11 +348,14 @@ export const FindMyFriend: MessageFns<FindMyFriend> = {
 };
 
 function createBaseGetFriendsRequest(): GetFriendsRequest {
-  return {};
+  return { friendIds: [] };
 }
 
 export const GetFriendsRequest: MessageFns<GetFriendsRequest> = {
-  encode(_: GetFriendsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(message: GetFriendsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.friendIds) {
+      writer.uint32(10).string(v!);
+    }
     return writer;
   },
 
@@ -362,6 +366,14 @@ export const GetFriendsRequest: MessageFns<GetFriendsRequest> = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.friendIds.push(reader.string());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -371,20 +383,30 @@ export const GetFriendsRequest: MessageFns<GetFriendsRequest> = {
     return message;
   },
 
-  fromJSON(_: any): GetFriendsRequest {
-    return {};
+  fromJSON(object: any): GetFriendsRequest {
+    return {
+      friendIds: globalThis.Array.isArray(object?.friendIds)
+        ? object.friendIds.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.friend_ids)
+        ? object.friend_ids.map((e: any) => globalThis.String(e))
+        : [],
+    };
   },
 
-  toJSON(_: GetFriendsRequest): unknown {
+  toJSON(message: GetFriendsRequest): unknown {
     const obj: any = {};
+    if (message.friendIds?.length) {
+      obj.friendIds = message.friendIds;
+    }
     return obj;
   },
 
   create(base?: DeepPartial<GetFriendsRequest>): GetFriendsRequest {
     return GetFriendsRequest.fromPartial(base ?? {});
   },
-  fromPartial(_: DeepPartial<GetFriendsRequest>): GetFriendsRequest {
+  fromPartial(object: DeepPartial<GetFriendsRequest>): GetFriendsRequest {
     const message = createBaseGetFriendsRequest();
+    message.friendIds = object.friendIds?.map((e) => e) || [];
     return message;
   },
 };
@@ -446,111 +468,6 @@ export const GetFriendsResponse: MessageFns<GetFriendsResponse> = {
   },
   fromPartial(object: DeepPartial<GetFriendsResponse>): GetFriendsResponse {
     const message = createBaseGetFriendsResponse();
-    message.friends = object.friends?.map((e) => FindMyFriend.fromPartial(e)) || [];
-    return message;
-  },
-};
-
-function createBaseRefreshFriendsRequest(): RefreshFriendsRequest {
-  return {};
-}
-
-export const RefreshFriendsRequest: MessageFns<RefreshFriendsRequest> = {
-  encode(_: RefreshFriendsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): RefreshFriendsRequest {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRefreshFriendsRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(_: any): RefreshFriendsRequest {
-    return {};
-  },
-
-  toJSON(_: RefreshFriendsRequest): unknown {
-    const obj: any = {};
-    return obj;
-  },
-
-  create(base?: DeepPartial<RefreshFriendsRequest>): RefreshFriendsRequest {
-    return RefreshFriendsRequest.fromPartial(base ?? {});
-  },
-  fromPartial(_: DeepPartial<RefreshFriendsRequest>): RefreshFriendsRequest {
-    const message = createBaseRefreshFriendsRequest();
-    return message;
-  },
-};
-
-function createBaseRefreshFriendsResponse(): RefreshFriendsResponse {
-  return { friends: [] };
-}
-
-export const RefreshFriendsResponse: MessageFns<RefreshFriendsResponse> = {
-  encode(message: RefreshFriendsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    for (const v of message.friends) {
-      FindMyFriend.encode(v!, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): RefreshFriendsResponse {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRefreshFriendsResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.friends.push(FindMyFriend.decode(reader, reader.uint32()));
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): RefreshFriendsResponse {
-    return {
-      friends: globalThis.Array.isArray(object?.friends)
-        ? object.friends.map((e: any) => FindMyFriend.fromJSON(e))
-        : [],
-    };
-  },
-
-  toJSON(message: RefreshFriendsResponse): unknown {
-    const obj: any = {};
-    if (message.friends?.length) {
-      obj.friends = message.friends.map((e) => FindMyFriend.toJSON(e));
-    }
-    return obj;
-  },
-
-  create(base?: DeepPartial<RefreshFriendsResponse>): RefreshFriendsResponse {
-    return RefreshFriendsResponse.fromPartial(base ?? {});
-  },
-  fromPartial(object: DeepPartial<RefreshFriendsResponse>): RefreshFriendsResponse {
-    const message = createBaseRefreshFriendsResponse();
     message.friends = object.friends?.map((e) => FindMyFriend.fromPartial(e)) || [];
     return message;
   },
@@ -749,6 +666,7 @@ export const LocationServiceDefinition = {
   name: "LocationService",
   fullName: "photon.imessage.v1.LocationService",
   methods: {
+    /** Returns the current cached snapshot and triggers a background refresh. */
     getFriends: {
       name: "GetFriends",
       requestType: GetFriendsRequest as typeof GetFriendsRequest,
@@ -757,14 +675,10 @@ export const LocationServiceDefinition = {
       responseStream: false,
       options: {},
     },
-    refreshFriends: {
-      name: "RefreshFriends",
-      requestType: RefreshFriendsRequest as typeof RefreshFriendsRequest,
-      requestStream: false,
-      responseType: RefreshFriendsResponse as typeof RefreshFriendsResponse,
-      responseStream: false,
-      options: {},
-    },
+    /**
+     * Forwards real helper push events. While at least one subscriber is active,
+     * the server triggers periodic background refreshes.
+     */
     subscribeLocationEvents: {
       name: "SubscribeLocationEvents",
       requestType: SubscribeLocationEventsRequest as typeof SubscribeLocationEventsRequest,
@@ -777,14 +691,15 @@ export const LocationServiceDefinition = {
 } as const;
 
 export interface LocationServiceImplementation<CallContextExt = {}> {
+  /** Returns the current cached snapshot and triggers a background refresh. */
   getFriends(
     request: GetFriendsRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<GetFriendsResponse>>;
-  refreshFriends(
-    request: RefreshFriendsRequest,
-    context: CallContext & CallContextExt,
-  ): Promise<DeepPartial<RefreshFriendsResponse>>;
+  /**
+   * Forwards real helper push events. While at least one subscriber is active,
+   * the server triggers periodic background refreshes.
+   */
   subscribeLocationEvents(
     request: SubscribeLocationEventsRequest,
     context: CallContext & CallContextExt,
@@ -792,14 +707,15 @@ export interface LocationServiceImplementation<CallContextExt = {}> {
 }
 
 export interface LocationServiceClient<CallOptionsExt = {}> {
+  /** Returns the current cached snapshot and triggers a background refresh. */
   getFriends(
     request: DeepPartial<GetFriendsRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<GetFriendsResponse>;
-  refreshFriends(
-    request: DeepPartial<RefreshFriendsRequest>,
-    options?: CallOptions & CallOptionsExt,
-  ): Promise<RefreshFriendsResponse>;
+  /**
+   * Forwards real helper push events. While at least one subscriber is active,
+   * the server triggers periodic background refreshes.
+   */
   subscribeLocationEvents(
     request: DeepPartial<SubscribeLocationEventsRequest>,
     options?: CallOptions & CallOptionsExt,

--- a/src/resources/locations.ts
+++ b/src/resources/locations.ts
@@ -28,20 +28,15 @@ export class LocationsResource {
   // Queries
   // -------------------------------------------------------------------------
 
-  /** Get the current list of Find My Friends with their last known locations. */
-  async getFriends(): Promise<FindMyFriend[]> {
+  /**
+   * Get the current cached Find My snapshot and trigger a server-side
+   * background refresh.
+   */
+  async getFriends(friendIds?: readonly string[]): Promise<FindMyFriend[]> {
     try {
-      const response = await this._client.getFriends({});
-      return response.friends.map(mapFindMyFriend);
-    } catch (error) {
-      throw fromGrpcError(error);
-    }
-  }
-
-  /** Force a refresh of friend locations and return the updated list. */
-  async refreshFriends(): Promise<FindMyFriend[]> {
-    try {
-      const response = await this._client.refreshFriends({});
+      const response = await this._client.getFriends({
+        friendIds: friendIds ? [...friendIds] : [],
+      });
       return response.friends.map(mapFindMyFriend);
     } catch (error) {
       throw fromGrpcError(error);
@@ -52,7 +47,7 @@ export class LocationsResource {
   // Event subscription
   // -------------------------------------------------------------------------
 
-  /** Subscribe to location update events. Returns a typed event stream. */
+  /** Subscribe to real-time location update events. Returns a typed stream. */
   subscribe(): TypedEventStream<LocationEvent> {
     const rpcStream = this._client.subscribeLocationEvents({});
 

--- a/src/transport/mapper.ts
+++ b/src/transport/mapper.ts
@@ -163,15 +163,22 @@ function mapScheduledMessageType(proto: ProtoScheduledMessageType): string {
 
 /**
  * Map a proto `FindMyLocationType` enum value to the SDK string literal.
+ *
+ * Older servers used `UNSPECIFIED` for legacy locations, so we treat the
+ * fallback path as `"legacy"` instead of silently misclassifying it.
  */
-function mapLocationType(proto: ProtoFindMyLocationType): "live" | "shallow" {
+function mapLocationType(
+  proto: ProtoFindMyLocationType
+): "legacy" | "live" | "shallow" {
   switch (proto) {
     case ProtoFindMyLocationType.FIND_MY_LOCATION_TYPE_LIVE:
       return "live";
     case ProtoFindMyLocationType.FIND_MY_LOCATION_TYPE_SHALLOW:
       return "shallow";
+    case ProtoFindMyLocationType.FIND_MY_LOCATION_TYPE_LEGACY:
+      return "legacy";
     default:
-      return "shallow";
+      return "legacy";
   }
 }
 

--- a/src/types/locations.ts
+++ b/src/types/locations.ts
@@ -23,8 +23,8 @@ export interface FindMyFriend {
   readonly latitude?: number;
   /** When this location fix was taken. */
   readonly locationTimestamp?: Date;
-  /** Whether this is a live or shallow (cached) location. */
-  readonly locationType: "live" | "shallow";
+  /** Whether this is a live, shallow (cached), or legacy location. */
+  readonly locationType: "legacy" | "live" | "shallow";
   /** Full street address, when available. */
   readonly longAddress?: string;
   /** Longitude in decimal degrees. */

--- a/tests/unit/locations.test.ts
+++ b/tests/unit/locations.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { FindMyLocationType } from "../../src/generated/photon/imessage/v1/location_service.ts";
+import { LocationsResource } from "../../src/resources/locations.ts";
+
+describe("LocationsResource", () => {
+  it("passes friendIds through getFriends requests", async () => {
+    const requests: Array<{ friendIds: string[] }> = [];
+    const resource = new LocationsResource({
+      async *subscribeLocationEvents() {
+        yield* [];
+      },
+      async getFriends(request: { friendIds?: string[] }) {
+        requests.push({ friendIds: request.friendIds ?? [] });
+        return { friends: [] };
+      },
+    } as any);
+
+    await resource.getFriends(["friend-1", "friend-2"]);
+
+    expect(requests).toEqual([
+      {
+        friendIds: ["friend-1", "friend-2"],
+      },
+    ]);
+  });
+
+  it("does not expose the removed refreshFriends API", () => {
+    const resource = new LocationsResource({
+      async *subscribeLocationEvents() {
+        yield* [];
+      },
+      async getFriends() {
+        return { friends: [] };
+      },
+    } as any);
+
+    expect("refreshFriends" in resource).toBe(false);
+  });
+
+  it("maps legacy location types from the proto enum", async () => {
+    const resource = new LocationsResource({
+      async *subscribeLocationEvents() {
+        yield* [];
+      },
+      async getFriends() {
+        return {
+          friends: [
+            {
+              id: "friend-legacy",
+              isLocatingInProgress: false,
+              locationType: FindMyLocationType.FIND_MY_LOCATION_TYPE_LEGACY,
+            },
+          ],
+        };
+      },
+    } as any);
+
+    const [friend] = await resource.getFriends();
+
+    expect(friend?.locationType).toBe("legacy");
+  });
+});


### PR DESCRIPTION
## Summary

This PR syncs the SDK location service with the current server contract.

- removes the deleted `RefreshFriends` RPC from the SDK surface
- regenerates the location gRPC/client code from the updated proto
- updates `getFriends(friendIds?)` to match the new request shape
- adds `legacy` support for `FindMyLocationType`
- keeps realtime location updates on `SubscribeLocationEvents`
- adds focused tests for the updated location behavior

## Testing

- `bun test tests/unit/locations.test.ts`
- End-to-end validation against the local server/helper flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional friend ID filtering parameter to getFriends for selective friend data retrieval.
  * Extended location type support to include legacy location type.

* **Refactoring**
  * Removed separate refreshFriends method; friend data refresh is now integrated into getFriends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->