### PR TITLE
feat(proto): add Heartbeat keepalive for streaming subscriptions

### DIFF
--- a/proto/photon/imessage/v1/chat_service.proto
+++ b/proto/photon/imessage/v1/chat_service.proto
@@ -4,6 +4,7 @@ package photon.imessage.v1;
 option swift_prefix = "PIMsg_";
 
 import "google/protobuf/timestamp.proto";
+import "photon/imessage/v1/common.proto";
 import "photon/imessage/v1/message_service.proto";
 
 // ---------------------------------------------------------------------------
@@ -127,6 +128,7 @@ message SubscribeChatEventsResponse {
     ChatLifecycleEvent chat_left = 14;
     ChatReadStatusEvent chat_read_status_changed = 10;
     TypingEvent typing_indicator = 11;
+    Heartbeat heartbeat = 99;
   }
 }
 

--- a/proto/photon/imessage/v1/common.proto
+++ b/proto/photon/imessage/v1/common.proto
@@ -10,6 +10,10 @@ message PaginatedMeta {
   int32 limit = 3;
 }
 
+// Keepalive signal for streaming RPCs behind proxies (e.g. Cloudflare Tunnel).
+// Clients should silently discard these.
+message Heartbeat {}
+
 // Sort direction for list queries.
 enum SortDirection {
   SORT_DIRECTION_UNSPECIFIED = 0;

--- a/proto/photon/imessage/v1/group_service.proto
+++ b/proto/photon/imessage/v1/group_service.proto
@@ -4,6 +4,7 @@ package photon.imessage.v1;
 option swift_prefix = "PIMsg_";
 
 import "google/protobuf/timestamp.proto";
+import "photon/imessage/v1/common.proto";
 import "photon/imessage/v1/chat_service.proto";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,7 @@ message SubscribeGroupEventsResponse {
   google.protobuf.Timestamp timestamp = 1;
   oneof payload {
     GroupChangeEvent group_changed = 10;
+    Heartbeat heartbeat = 99;
   }
 }
 

--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -304,6 +304,7 @@ message SubscribeMessageEventsResponse {
     MessageReceivedEvent message_received = 11;
     MessageUpdatedEvent message_updated = 12;
     MessageSendErrorEvent message_send_error = 13;
+    Heartbeat heartbeat = 99;
   }
 }
 

--- a/proto/photon/imessage/v1/poll_service.proto
+++ b/proto/photon/imessage/v1/poll_service.proto
@@ -4,6 +4,7 @@ package photon.imessage.v1;
 option swift_prefix = "PIMsg_";
 
 import "google/protobuf/timestamp.proto";
+import "photon/imessage/v1/common.proto";
 import "photon/imessage/v1/message_service.proto";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,7 @@ message SubscribePollEventsResponse {
   google.protobuf.Timestamp timestamp = 1;
   oneof payload {
     PollChangeEvent poll_changed = 10;
+    Heartbeat heartbeat = 99;
   }
 }
 

--- a/proto/photon/imessage/v1/scheduled_message_service.proto
+++ b/proto/photon/imessage/v1/scheduled_message_service.proto
@@ -4,6 +4,7 @@ package photon.imessage.v1;
 option swift_prefix = "PIMsg_";
 
 import "google/protobuf/timestamp.proto";
+import "photon/imessage/v1/common.proto";
 
 // ---------------------------------------------------------------------------
 // Service
@@ -125,6 +126,7 @@ message SubscribeScheduleEventsResponse {
   google.protobuf.Timestamp timestamp = 1;
   oneof payload {
     ScheduledMessageEvent scheduled_message_changed = 10;
+    Heartbeat heartbeat = 99;
   }
 }
 

--- a/src/generated/photon/imessage/v1/chat_service.ts
+++ b/src/generated/photon/imessage/v1/chat_service.ts
@@ -8,6 +8,7 @@
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
+import { Heartbeat } from "./common.js";
 import { AddressInfo, Message, MessageSendReceipt } from "./message_service.js";
 
 export const protobufPackage = "photon.imessage.v1";
@@ -109,6 +110,7 @@ export interface SubscribeChatEventsResponse {
   chatLeft?: ChatLifecycleEvent | undefined;
   chatReadStatusChanged?: ChatReadStatusEvent | undefined;
   typingIndicator?: TypingEvent | undefined;
+  heartbeat?: Heartbeat | undefined;
 }
 
 export interface ChatLifecycleEvent {
@@ -1597,6 +1599,7 @@ function createBaseSubscribeChatEventsResponse(): SubscribeChatEventsResponse {
     chatLeft: undefined,
     chatReadStatusChanged: undefined,
     typingIndicator: undefined,
+    heartbeat: undefined,
   };
 }
 
@@ -1616,6 +1619,9 @@ export const SubscribeChatEventsResponse: MessageFns<SubscribeChatEventsResponse
     }
     if (message.typingIndicator !== undefined) {
       TypingEvent.encode(message.typingIndicator, writer.uint32(90).fork()).join();
+    }
+    if (message.heartbeat !== undefined) {
+      Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
     }
     return writer;
   },
@@ -1667,6 +1673,14 @@ export const SubscribeChatEventsResponse: MessageFns<SubscribeChatEventsResponse
           message.typingIndicator = TypingEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 99: {
+          if (tag !== 794) {
+            break;
+          }
+
+          message.heartbeat = Heartbeat.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1699,6 +1713,7 @@ export const SubscribeChatEventsResponse: MessageFns<SubscribeChatEventsResponse
         : isSet(object.typing_indicator)
         ? TypingEvent.fromJSON(object.typing_indicator)
         : undefined,
+      heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
 
@@ -1718,6 +1733,9 @@ export const SubscribeChatEventsResponse: MessageFns<SubscribeChatEventsResponse
     }
     if (message.typingIndicator !== undefined) {
       obj.typingIndicator = TypingEvent.toJSON(message.typingIndicator);
+    }
+    if (message.heartbeat !== undefined) {
+      obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
     return obj;
   },
@@ -1740,6 +1758,9 @@ export const SubscribeChatEventsResponse: MessageFns<SubscribeChatEventsResponse
         : undefined;
     message.typingIndicator = (object.typingIndicator !== undefined && object.typingIndicator !== null)
       ? TypingEvent.fromPartial(object.typingIndicator)
+      : undefined;
+    message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
+      ? Heartbeat.fromPartial(object.heartbeat)
       : undefined;
     return message;
   },

--- a/src/generated/photon/imessage/v1/common.ts
+++ b/src/generated/photon/imessage/v1/common.ts
@@ -56,6 +56,13 @@ export interface PaginatedMeta {
   limit: number;
 }
 
+/**
+ * Keepalive signal for streaming RPCs behind proxies (e.g. Cloudflare Tunnel).
+ * Clients should silently discard these.
+ */
+export interface Heartbeat {
+}
+
 function createBasePaginatedMeta(): PaginatedMeta {
   return { total: 0, offset: 0, limit: 0 };
 }
@@ -144,6 +151,49 @@ export const PaginatedMeta: MessageFns<PaginatedMeta> = {
     message.total = object.total ?? 0;
     message.offset = object.offset ?? 0;
     message.limit = object.limit ?? 0;
+    return message;
+  },
+};
+
+function createBaseHeartbeat(): Heartbeat {
+  return {};
+}
+
+export const Heartbeat: MessageFns<Heartbeat> = {
+  encode(_: Heartbeat, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): Heartbeat {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseHeartbeat();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): Heartbeat {
+    return {};
+  },
+
+  toJSON(_: Heartbeat): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<Heartbeat>): Heartbeat {
+    return Heartbeat.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<Heartbeat>): Heartbeat {
+    const message = createBaseHeartbeat();
     return message;
   },
 };

--- a/src/generated/photon/imessage/v1/group_service.ts
+++ b/src/generated/photon/imessage/v1/group_service.ts
@@ -9,6 +9,7 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
 import { Chat } from "./chat_service.js";
+import { Heartbeat } from "./common.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
@@ -96,6 +97,7 @@ export interface SubscribeGroupEventsRequest {
 export interface SubscribeGroupEventsResponse {
   timestamp: Date | undefined;
   groupChanged?: GroupChangeEvent | undefined;
+  heartbeat?: Heartbeat | undefined;
 }
 
 export interface IconChanged {
@@ -1390,7 +1392,7 @@ export const SubscribeGroupEventsRequest: MessageFns<SubscribeGroupEventsRequest
 };
 
 function createBaseSubscribeGroupEventsResponse(): SubscribeGroupEventsResponse {
-  return { timestamp: undefined, groupChanged: undefined };
+  return { timestamp: undefined, groupChanged: undefined, heartbeat: undefined };
 }
 
 export const SubscribeGroupEventsResponse: MessageFns<SubscribeGroupEventsResponse> = {
@@ -1400,6 +1402,9 @@ export const SubscribeGroupEventsResponse: MessageFns<SubscribeGroupEventsRespon
     }
     if (message.groupChanged !== undefined) {
       GroupChangeEvent.encode(message.groupChanged, writer.uint32(82).fork()).join();
+    }
+    if (message.heartbeat !== undefined) {
+      Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
     }
     return writer;
   },
@@ -1427,6 +1432,14 @@ export const SubscribeGroupEventsResponse: MessageFns<SubscribeGroupEventsRespon
           message.groupChanged = GroupChangeEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 99: {
+          if (tag !== 794) {
+            break;
+          }
+
+          message.heartbeat = Heartbeat.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1444,6 +1457,7 @@ export const SubscribeGroupEventsResponse: MessageFns<SubscribeGroupEventsRespon
         : isSet(object.group_changed)
         ? GroupChangeEvent.fromJSON(object.group_changed)
         : undefined,
+      heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
 
@@ -1454,6 +1468,9 @@ export const SubscribeGroupEventsResponse: MessageFns<SubscribeGroupEventsRespon
     }
     if (message.groupChanged !== undefined) {
       obj.groupChanged = GroupChangeEvent.toJSON(message.groupChanged);
+    }
+    if (message.heartbeat !== undefined) {
+      obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
     return obj;
   },
@@ -1466,6 +1483,9 @@ export const SubscribeGroupEventsResponse: MessageFns<SubscribeGroupEventsRespon
     message.timestamp = object.timestamp ?? undefined;
     message.groupChanged = (object.groupChanged !== undefined && object.groupChanged !== null)
       ? GroupChangeEvent.fromPartial(object.groupChanged)
+      : undefined;
+    message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
+      ? Heartbeat.fromPartial(object.heartbeat)
       : undefined;
     return message;
   },

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -8,7 +8,7 @@
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
-import { PaginatedMeta, SortDirection, sortDirectionFromJSON, sortDirectionToJSON } from "./common.js";
+import { Heartbeat, PaginatedMeta, SortDirection, sortDirectionFromJSON, sortDirectionToJSON } from "./common.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
@@ -375,6 +375,7 @@ export interface SubscribeMessageEventsResponse {
   messageReceived?: MessageReceivedEvent | undefined;
   messageUpdated?: MessageUpdatedEvent | undefined;
   messageSendError?: MessageSendErrorEvent | undefined;
+  heartbeat?: Heartbeat | undefined;
 }
 
 export interface MessageSentEvent {
@@ -4395,6 +4396,7 @@ function createBaseSubscribeMessageEventsResponse(): SubscribeMessageEventsRespo
     messageReceived: undefined,
     messageUpdated: undefined,
     messageSendError: undefined,
+    heartbeat: undefined,
   };
 }
 
@@ -4414,6 +4416,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageSendError !== undefined) {
       MessageSendErrorEvent.encode(message.messageSendError, writer.uint32(106).fork()).join();
+    }
+    if (message.heartbeat !== undefined) {
+      Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
     }
     return writer;
   },
@@ -4465,6 +4470,14 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
           message.messageSendError = MessageSendErrorEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 99: {
+          if (tag !== 794) {
+            break;
+          }
+
+          message.heartbeat = Heartbeat.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -4497,6 +4510,7 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
         : isSet(object.message_send_error)
         ? MessageSendErrorEvent.fromJSON(object.message_send_error)
         : undefined,
+      heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
 
@@ -4516,6 +4530,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageSendError !== undefined) {
       obj.messageSendError = MessageSendErrorEvent.toJSON(message.messageSendError);
+    }
+    if (message.heartbeat !== undefined) {
+      obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
     return obj;
   },
@@ -4537,6 +4554,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
       : undefined;
     message.messageSendError = (object.messageSendError !== undefined && object.messageSendError !== null)
       ? MessageSendErrorEvent.fromPartial(object.messageSendError)
+      : undefined;
+    message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
+      ? Heartbeat.fromPartial(object.heartbeat)
       : undefined;
     return message;
   },

--- a/src/generated/photon/imessage/v1/poll_service.ts
+++ b/src/generated/photon/imessage/v1/poll_service.ts
@@ -8,6 +8,7 @@
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
+import { Heartbeat } from "./common.js";
 import { Message, MessageCommandReceipt } from "./message_service.js";
 
 export const protobufPackage = "photon.imessage.v1";
@@ -84,6 +85,7 @@ export interface SubscribePollEventsRequest {
 export interface SubscribePollEventsResponse {
   timestamp: Date | undefined;
   pollChanged?: PollChangeEvent | undefined;
+  heartbeat?: Heartbeat | undefined;
 }
 
 export interface PollChangeEvent {
@@ -1203,7 +1205,7 @@ export const SubscribePollEventsRequest: MessageFns<SubscribePollEventsRequest> 
 };
 
 function createBaseSubscribePollEventsResponse(): SubscribePollEventsResponse {
-  return { timestamp: undefined, pollChanged: undefined };
+  return { timestamp: undefined, pollChanged: undefined, heartbeat: undefined };
 }
 
 export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse> = {
@@ -1213,6 +1215,9 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
     }
     if (message.pollChanged !== undefined) {
       PollChangeEvent.encode(message.pollChanged, writer.uint32(82).fork()).join();
+    }
+    if (message.heartbeat !== undefined) {
+      Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
     }
     return writer;
   },
@@ -1240,6 +1245,14 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
           message.pollChanged = PollChangeEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 99: {
+          if (tag !== 794) {
+            break;
+          }
+
+          message.heartbeat = Heartbeat.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1257,6 +1270,7 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
         : isSet(object.poll_changed)
         ? PollChangeEvent.fromJSON(object.poll_changed)
         : undefined,
+      heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
 
@@ -1267,6 +1281,9 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
     }
     if (message.pollChanged !== undefined) {
       obj.pollChanged = PollChangeEvent.toJSON(message.pollChanged);
+    }
+    if (message.heartbeat !== undefined) {
+      obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
     return obj;
   },
@@ -1279,6 +1296,9 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
     message.timestamp = object.timestamp ?? undefined;
     message.pollChanged = (object.pollChanged !== undefined && object.pollChanged !== null)
       ? PollChangeEvent.fromPartial(object.pollChanged)
+      : undefined;
+    message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
+      ? Heartbeat.fromPartial(object.heartbeat)
       : undefined;
     return message;
   },

--- a/src/generated/photon/imessage/v1/scheduled_message_service.ts
+++ b/src/generated/photon/imessage/v1/scheduled_message_service.ts
@@ -8,6 +8,7 @@
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
+import { Heartbeat } from "./common.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
@@ -179,6 +180,7 @@ export interface SubscribeScheduleEventsRequest {
 export interface SubscribeScheduleEventsResponse {
   timestamp: Date | undefined;
   scheduledMessageChanged?: ScheduledMessageEvent | undefined;
+  heartbeat?: Heartbeat | undefined;
 }
 
 export interface ScheduledMessageEvent {
@@ -1461,7 +1463,7 @@ export const SubscribeScheduleEventsRequest: MessageFns<SubscribeScheduleEventsR
 };
 
 function createBaseSubscribeScheduleEventsResponse(): SubscribeScheduleEventsResponse {
-  return { timestamp: undefined, scheduledMessageChanged: undefined };
+  return { timestamp: undefined, scheduledMessageChanged: undefined, heartbeat: undefined };
 }
 
 export const SubscribeScheduleEventsResponse: MessageFns<SubscribeScheduleEventsResponse> = {
@@ -1471,6 +1473,9 @@ export const SubscribeScheduleEventsResponse: MessageFns<SubscribeScheduleEvents
     }
     if (message.scheduledMessageChanged !== undefined) {
       ScheduledMessageEvent.encode(message.scheduledMessageChanged, writer.uint32(82).fork()).join();
+    }
+    if (message.heartbeat !== undefined) {
+      Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
     }
     return writer;
   },
@@ -1498,6 +1503,14 @@ export const SubscribeScheduleEventsResponse: MessageFns<SubscribeScheduleEvents
           message.scheduledMessageChanged = ScheduledMessageEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 99: {
+          if (tag !== 794) {
+            break;
+          }
+
+          message.heartbeat = Heartbeat.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1515,6 +1528,7 @@ export const SubscribeScheduleEventsResponse: MessageFns<SubscribeScheduleEvents
         : isSet(object.scheduled_message_changed)
         ? ScheduledMessageEvent.fromJSON(object.scheduled_message_changed)
         : undefined,
+      heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
 
@@ -1525,6 +1539,9 @@ export const SubscribeScheduleEventsResponse: MessageFns<SubscribeScheduleEvents
     }
     if (message.scheduledMessageChanged !== undefined) {
       obj.scheduledMessageChanged = ScheduledMessageEvent.toJSON(message.scheduledMessageChanged);
+    }
+    if (message.heartbeat !== undefined) {
+      obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
     return obj;
   },
@@ -1539,6 +1556,9 @@ export const SubscribeScheduleEventsResponse: MessageFns<SubscribeScheduleEvents
       (object.scheduledMessageChanged !== undefined && object.scheduledMessageChanged !== null)
         ? ScheduledMessageEvent.fromPartial(object.scheduledMessageChanged)
         : undefined;
+    message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
+      ? Heartbeat.fromPartial(object.heartbeat)
+      : undefined;
     return message;
   },
 };


### PR DESCRIPTION
### Summary

Introduces a wire-level **heartbeat** payload for long-lived gRPC streaming subscriptions so intermediaries (for example **Cloudflare Tunnel** or other HTTP/2 proxies) are less likely to tear down idle streams. The payload is an empty `Heartbeat` message; **clients should treat it as a no-op** and discard it silently.

### Changes

- **`common.proto`**: add `message Heartbeat {}` with documentation describing keepalive semantics.
- **Streaming subscription responses**: extend the `oneof payload` / equivalent union on:
  - `SubscribeChatEventsResponse`
  - `SubscribeGroupEventsResponse`
  - `SubscribeMessageEventsResponse`
  - `SubscribePollEventsResponse`
  - `SubscribeScheduleEventsResponse`
  with `Heartbeat heartbeat = 99` (and `import` `common.proto` where required).
- **`src/generated/...`**: regenerate TypeScript encode/decode/JSON helpers for the above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added heartbeat support to event streaming across chat, messaging, group, poll, and scheduled message APIs to enhance connection stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->