### PR TITLE
feat: add cursor-based stream catch-up and fetchMissed API

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -138,11 +138,13 @@ No pagination API to learn. Standard JS iteration handles it.
 
 ```ts
 type MessageEvent =
-  | { type: "message.sent"; message: Message; chatGuid: ChatGuid }
-  | { type: "message.received"; message: Message; chatGuid: ChatGuid }
-  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction" }
-  | { type: "message.sendError"; errorCode: string; errorMessage: string };
+  | { type: "message.sent"; message: Message; chatGuid: ChatGuid; cursor?: string }
+  | { type: "message.received"; message: Message; chatGuid: ChatGuid; cursor?: string }
+  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction"; cursor?: string }
+  | { type: "message.sendError"; errorCode: string; errorMessage: string; cursor?: string };
 ```
+
+Each event carries an opaque `cursor` — a position marker for catching up after a disconnect. See [Stream Catch-Up](#stream-catch-up) below.
 
 `subscribe()` is overloaded — passing a type string narrows the return:
 
@@ -167,6 +169,36 @@ for await (const { from, text } of incoming) {
   console.log(`[${from}] ${text}`);
 }
 ```
+
+---
+
+## Stream Catch-Up
+
+When a stream disconnects, messages keep arriving on the server. The SDK exposes cursor-based catch-up so you never lose messages:
+
+```ts
+let cursor = loadPersistedCursor(); // your storage
+
+// 1. Catch up on anything missed while disconnected
+if (cursor) {
+  for await (const msg of im.messages.fetchMissed(cursor)) {
+    processMissedMessage(msg);
+  }
+}
+
+// 2. Resume live stream, tracking cursor for next time
+for await (const event of im.messages.subscribe()) {
+  if (event.cursor) cursor = event.cursor;
+  processEvent(event);
+}
+
+// 3. Persist cursor when done (or periodically)
+persistCursor(cursor);
+```
+
+`fetchMissed(cursor)` returns `Paginated<Message>` — same auto-pagination as `list()`. It fetches every message after the cursor position, ordered chronologically, with full chat and attachment metadata.
+
+The cursor is opaque — treat it as a string, persist it, pass it back. The server handles the rest.
 
 ---
 

--- a/proto/photon/imessage/v1/common.proto
+++ b/proto/photon/imessage/v1/common.proto
@@ -20,3 +20,16 @@ enum SortDirection {
   SORT_DIRECTION_DESCENDING = 1;
   SORT_DIRECTION_ASCENDING = 2;
 }
+
+// Opaque cursor for resumable event streams.
+// Clients must treat the value as opaque and pass it back verbatim.
+message StreamCursor {
+  string value = 1;
+}
+
+// Sent when a client's cursor is no longer valid (e.g. server reinstalled,
+// chat.db reset). The client should discard its stored cursor and optionally
+// use ListMessages to catch up.
+message CursorReset {
+  StreamCursor current_position = 1;
+}

--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -262,6 +262,7 @@ message ListMessagesRequest {
   int32 offset = 6;
   bool with_chats = 7;
   bool with_attachments = 8;
+  optional StreamCursor after_cursor = 9;
 }
 
 message ListMessagesResponse {
@@ -295,15 +296,19 @@ message GetMessageStatsResponse {
 // Event streaming
 // ---------------------------------------------------------------------------
 
-message SubscribeMessageEventsRequest {}
+message SubscribeMessageEventsRequest {
+  optional StreamCursor cursor = 1;
+}
 
 message SubscribeMessageEventsResponse {
   google.protobuf.Timestamp timestamp = 1;
+  optional StreamCursor cursor = 2;
   oneof payload {
     MessageSentEvent message_sent = 10;
     MessageReceivedEvent message_received = 11;
     MessageUpdatedEvent message_updated = 12;
     MessageSendErrorEvent message_send_error = 13;
+    CursorReset cursor_reset = 98;
     Heartbeat heartbeat = 99;
   }
 }

--- a/src/generated/photon/imessage/v1/common.ts
+++ b/src/generated/photon/imessage/v1/common.ts
@@ -63,6 +63,23 @@ export interface PaginatedMeta {
 export interface Heartbeat {
 }
 
+/**
+ * Opaque cursor for resumable event streams.
+ * Clients must treat the value as opaque and pass it back verbatim.
+ */
+export interface StreamCursor {
+  value: string;
+}
+
+/**
+ * Sent when a client's cursor is no longer valid (e.g. server reinstalled,
+ * chat.db reset). The client should discard its stored cursor and optionally
+ * use ListMessages to catch up.
+ */
+export interface CursorReset {
+  currentPosition: StreamCursor | undefined;
+}
+
 function createBasePaginatedMeta(): PaginatedMeta {
   return { total: 0, offset: 0, limit: 0 };
 }
@@ -194,6 +211,130 @@ export const Heartbeat: MessageFns<Heartbeat> = {
   },
   fromPartial(_: DeepPartial<Heartbeat>): Heartbeat {
     const message = createBaseHeartbeat();
+    return message;
+  },
+};
+
+function createBaseStreamCursor(): StreamCursor {
+  return { value: "" };
+}
+
+export const StreamCursor: MessageFns<StreamCursor> = {
+  encode(message: StreamCursor, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.value !== "") {
+      writer.uint32(10).string(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): StreamCursor {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStreamCursor();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.value = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StreamCursor {
+    return { value: isSet(object.value) ? globalThis.String(object.value) : "" };
+  },
+
+  toJSON(message: StreamCursor): unknown {
+    const obj: any = {};
+    if (message.value !== "") {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<StreamCursor>): StreamCursor {
+    return StreamCursor.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<StreamCursor>): StreamCursor {
+    const message = createBaseStreamCursor();
+    message.value = object.value ?? "";
+    return message;
+  },
+};
+
+function createBaseCursorReset(): CursorReset {
+  return { currentPosition: undefined };
+}
+
+export const CursorReset: MessageFns<CursorReset> = {
+  encode(message: CursorReset, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.currentPosition !== undefined) {
+      StreamCursor.encode(message.currentPosition, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): CursorReset {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseCursorReset();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.currentPosition = StreamCursor.decode(reader, reader.uint32());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): CursorReset {
+    return {
+      currentPosition: isSet(object.currentPosition)
+        ? StreamCursor.fromJSON(object.currentPosition)
+        : isSet(object.current_position)
+        ? StreamCursor.fromJSON(object.current_position)
+        : undefined,
+    };
+  },
+
+  toJSON(message: CursorReset): unknown {
+    const obj: any = {};
+    if (message.currentPosition !== undefined) {
+      obj.currentPosition = StreamCursor.toJSON(message.currentPosition);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<CursorReset>): CursorReset {
+    return CursorReset.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<CursorReset>): CursorReset {
+    const message = createBaseCursorReset();
+    message.currentPosition = (object.currentPosition !== undefined && object.currentPosition !== null)
+      ? StreamCursor.fromPartial(object.currentPosition)
+      : undefined;
     return message;
   },
 };

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -8,7 +8,15 @@
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
-import { Heartbeat, PaginatedMeta, SortDirection, sortDirectionFromJSON, sortDirectionToJSON } from "./common.js";
+import {
+  CursorReset,
+  Heartbeat,
+  PaginatedMeta,
+  SortDirection,
+  sortDirectionFromJSON,
+  sortDirectionToJSON,
+  StreamCursor,
+} from "./common.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
@@ -336,6 +344,7 @@ export interface ListMessagesRequest {
   offset: number;
   withChats: boolean;
   withAttachments: boolean;
+  afterCursor?: StreamCursor | undefined;
 }
 
 export interface ListMessagesResponse {
@@ -367,14 +376,17 @@ export interface GetMessageStatsResponse {
 }
 
 export interface SubscribeMessageEventsRequest {
+  cursor?: StreamCursor | undefined;
 }
 
 export interface SubscribeMessageEventsResponse {
   timestamp: Date | undefined;
+  cursor?: StreamCursor | undefined;
   messageSent?: MessageSentEvent | undefined;
   messageReceived?: MessageReceivedEvent | undefined;
   messageUpdated?: MessageUpdatedEvent | undefined;
   messageSendError?: MessageSendErrorEvent | undefined;
+  cursorReset?: CursorReset | undefined;
   heartbeat?: Heartbeat | undefined;
 }
 
@@ -3726,6 +3738,7 @@ function createBaseListMessagesRequest(): ListMessagesRequest {
     offset: 0,
     withChats: false,
     withAttachments: false,
+    afterCursor: undefined,
   };
 }
 
@@ -3754,6 +3767,9 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
     }
     if (message.withAttachments !== false) {
       writer.uint32(64).bool(message.withAttachments);
+    }
+    if (message.afterCursor !== undefined) {
+      StreamCursor.encode(message.afterCursor, writer.uint32(74).fork()).join();
     }
     return writer;
   },
@@ -3829,6 +3845,14 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
           message.withAttachments = reader.bool();
           continue;
         }
+        case 9: {
+          if (tag !== 74) {
+            break;
+          }
+
+          message.afterCursor = StreamCursor.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3860,6 +3884,11 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
         : isSet(object.with_attachments)
         ? globalThis.Boolean(object.with_attachments)
         : false,
+      afterCursor: isSet(object.afterCursor)
+        ? StreamCursor.fromJSON(object.afterCursor)
+        : isSet(object.after_cursor)
+        ? StreamCursor.fromJSON(object.after_cursor)
+        : undefined,
     };
   },
 
@@ -3889,6 +3918,9 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
     if (message.withAttachments !== false) {
       obj.withAttachments = message.withAttachments;
     }
+    if (message.afterCursor !== undefined) {
+      obj.afterCursor = StreamCursor.toJSON(message.afterCursor);
+    }
     return obj;
   },
 
@@ -3905,6 +3937,9 @@ export const ListMessagesRequest: MessageFns<ListMessagesRequest> = {
     message.offset = object.offset ?? 0;
     message.withChats = object.withChats ?? false;
     message.withAttachments = object.withAttachments ?? false;
+    message.afterCursor = (object.afterCursor !== undefined && object.afterCursor !== null)
+      ? StreamCursor.fromPartial(object.afterCursor)
+      : undefined;
     return message;
   },
 };
@@ -4347,11 +4382,14 @@ export const GetMessageStatsResponse: MessageFns<GetMessageStatsResponse> = {
 };
 
 function createBaseSubscribeMessageEventsRequest(): SubscribeMessageEventsRequest {
-  return {};
+  return { cursor: undefined };
 }
 
 export const SubscribeMessageEventsRequest: MessageFns<SubscribeMessageEventsRequest> = {
-  encode(_: SubscribeMessageEventsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(message: SubscribeMessageEventsRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.cursor !== undefined) {
+      StreamCursor.encode(message.cursor, writer.uint32(10).fork()).join();
+    }
     return writer;
   },
 
@@ -4362,6 +4400,14 @@ export const SubscribeMessageEventsRequest: MessageFns<SubscribeMessageEventsReq
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.cursor = StreamCursor.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -4371,20 +4417,26 @@ export const SubscribeMessageEventsRequest: MessageFns<SubscribeMessageEventsReq
     return message;
   },
 
-  fromJSON(_: any): SubscribeMessageEventsRequest {
-    return {};
+  fromJSON(object: any): SubscribeMessageEventsRequest {
+    return { cursor: isSet(object.cursor) ? StreamCursor.fromJSON(object.cursor) : undefined };
   },
 
-  toJSON(_: SubscribeMessageEventsRequest): unknown {
+  toJSON(message: SubscribeMessageEventsRequest): unknown {
     const obj: any = {};
+    if (message.cursor !== undefined) {
+      obj.cursor = StreamCursor.toJSON(message.cursor);
+    }
     return obj;
   },
 
   create(base?: DeepPartial<SubscribeMessageEventsRequest>): SubscribeMessageEventsRequest {
     return SubscribeMessageEventsRequest.fromPartial(base ?? {});
   },
-  fromPartial(_: DeepPartial<SubscribeMessageEventsRequest>): SubscribeMessageEventsRequest {
+  fromPartial(object: DeepPartial<SubscribeMessageEventsRequest>): SubscribeMessageEventsRequest {
     const message = createBaseSubscribeMessageEventsRequest();
+    message.cursor = (object.cursor !== undefined && object.cursor !== null)
+      ? StreamCursor.fromPartial(object.cursor)
+      : undefined;
     return message;
   },
 };
@@ -4392,10 +4444,12 @@ export const SubscribeMessageEventsRequest: MessageFns<SubscribeMessageEventsReq
 function createBaseSubscribeMessageEventsResponse(): SubscribeMessageEventsResponse {
   return {
     timestamp: undefined,
+    cursor: undefined,
     messageSent: undefined,
     messageReceived: undefined,
     messageUpdated: undefined,
     messageSendError: undefined,
+    cursorReset: undefined,
     heartbeat: undefined,
   };
 }
@@ -4404,6 +4458,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
   encode(message: SubscribeMessageEventsResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.timestamp !== undefined) {
       Timestamp.encode(toTimestamp(message.timestamp), writer.uint32(10).fork()).join();
+    }
+    if (message.cursor !== undefined) {
+      StreamCursor.encode(message.cursor, writer.uint32(18).fork()).join();
     }
     if (message.messageSent !== undefined) {
       MessageSentEvent.encode(message.messageSent, writer.uint32(82).fork()).join();
@@ -4416,6 +4473,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageSendError !== undefined) {
       MessageSendErrorEvent.encode(message.messageSendError, writer.uint32(106).fork()).join();
+    }
+    if (message.cursorReset !== undefined) {
+      CursorReset.encode(message.cursorReset, writer.uint32(786).fork()).join();
     }
     if (message.heartbeat !== undefined) {
       Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
@@ -4436,6 +4496,14 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
           }
 
           message.timestamp = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.cursor = StreamCursor.decode(reader, reader.uint32());
           continue;
         }
         case 10: {
@@ -4470,6 +4538,14 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
           message.messageSendError = MessageSendErrorEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 98: {
+          if (tag !== 786) {
+            break;
+          }
+
+          message.cursorReset = CursorReset.decode(reader, reader.uint32());
+          continue;
+        }
         case 99: {
           if (tag !== 794) {
             break;
@@ -4490,6 +4566,7 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
   fromJSON(object: any): SubscribeMessageEventsResponse {
     return {
       timestamp: isSet(object.timestamp) ? fromJsonTimestamp(object.timestamp) : undefined,
+      cursor: isSet(object.cursor) ? StreamCursor.fromJSON(object.cursor) : undefined,
       messageSent: isSet(object.messageSent)
         ? MessageSentEvent.fromJSON(object.messageSent)
         : isSet(object.message_sent)
@@ -4510,6 +4587,11 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
         : isSet(object.message_send_error)
         ? MessageSendErrorEvent.fromJSON(object.message_send_error)
         : undefined,
+      cursorReset: isSet(object.cursorReset)
+        ? CursorReset.fromJSON(object.cursorReset)
+        : isSet(object.cursor_reset)
+        ? CursorReset.fromJSON(object.cursor_reset)
+        : undefined,
       heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
@@ -4518,6 +4600,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     const obj: any = {};
     if (message.timestamp !== undefined) {
       obj.timestamp = message.timestamp.toISOString();
+    }
+    if (message.cursor !== undefined) {
+      obj.cursor = StreamCursor.toJSON(message.cursor);
     }
     if (message.messageSent !== undefined) {
       obj.messageSent = MessageSentEvent.toJSON(message.messageSent);
@@ -4531,6 +4616,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     if (message.messageSendError !== undefined) {
       obj.messageSendError = MessageSendErrorEvent.toJSON(message.messageSendError);
     }
+    if (message.cursorReset !== undefined) {
+      obj.cursorReset = CursorReset.toJSON(message.cursorReset);
+    }
     if (message.heartbeat !== undefined) {
       obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
@@ -4543,6 +4631,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
   fromPartial(object: DeepPartial<SubscribeMessageEventsResponse>): SubscribeMessageEventsResponse {
     const message = createBaseSubscribeMessageEventsResponse();
     message.timestamp = object.timestamp ?? undefined;
+    message.cursor = (object.cursor !== undefined && object.cursor !== null)
+      ? StreamCursor.fromPartial(object.cursor)
+      : undefined;
     message.messageSent = (object.messageSent !== undefined && object.messageSent !== null)
       ? MessageSentEvent.fromPartial(object.messageSent)
       : undefined;
@@ -4554,6 +4645,9 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
       : undefined;
     message.messageSendError = (object.messageSendError !== undefined && object.messageSendError !== null)
       ? MessageSendErrorEvent.fromPartial(object.messageSendError)
+      : undefined;
+    message.cursorReset = (object.cursorReset !== undefined && object.cursorReset !== null)
+      ? CursorReset.fromPartial(object.cursorReset)
       : undefined;
     message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
       ? Heartbeat.fromPartial(object.heartbeat)

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export type { FindMyFriend } from "./types/locations.js";
 export type {
   ComposedMessage,
   EmbeddedMediaItem,
+  FetchMissedOptions,
   Message,
   MessageListOptions,
   MessagePart,

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -31,6 +31,7 @@ import type { MessageEvent } from "../types/events.ts";
 import type {
   ComposedMessage,
   EmbeddedMediaItem,
+  FetchMissedOptions,
   Message,
   MessageListOptions,
   MessagePart,
@@ -462,6 +463,9 @@ export class MessagesResource {
             offset,
             withChats: options?.withChats ?? false,
             withAttachments: options?.withAttachments ?? false,
+            afterCursor: options?.afterCursor
+              ? { value: options.afterCursor }
+              : undefined,
           });
 
           const meta = response.meta ?? { total: 0, offset: 0, limit };
@@ -480,6 +484,42 @@ export class MessagesResource {
       },
       { limit: options?.limit, offset: options?.offset }
     );
+  }
+
+  /**
+   * Fetch messages missed during a disconnect, using a cursor obtained from
+   * a previous `subscribe()` event.
+   *
+   * This is the recommended way to catch up after a stream disconnection.
+   * Results are ordered chronologically (ascending by ROWID) so they can
+   * be replayed in order.
+   *
+   * @example
+   * ```ts
+   * let cursor = loadPersistedCursor();
+   *
+   * // Catch up on missed messages
+   * if (cursor) {
+   *   for await (const msg of client.messages.fetchMissed(cursor)) {
+   *     processMissedMessage(msg);
+   *   }
+   * }
+   *
+   * // Resume live stream
+   * for await (const event of client.messages.subscribe()) {
+   *   if (event.cursor) cursor = event.cursor;
+   *   processEvent(event);
+   * }
+   * ```
+   */
+  fetchMissed(cursor: string, options?: FetchMissedOptions): Paginated<Message> {
+    return this.list({
+      afterCursor: cursor,
+      chatGuid: options?.chatGuid,
+      limit: options?.limit,
+      withChats: true,
+      withAttachments: true,
+    });
   }
 
   /**
@@ -560,6 +600,7 @@ export class MessagesResource {
       try {
         for await (const proto of rpcStream) {
           const timestamp = proto.timestamp ?? new Date();
+          const cursor = proto.cursor?.value || undefined;
 
           if (proto.messageSent !== undefined) {
             const evt: MessageSentEvent = proto.messageSent;
@@ -569,6 +610,7 @@ export class MessagesResource {
               message: mapMessage(unwrap(evt.message, "message")),
               clientMessageId: evt.clientMessageId,
               chatGuid: chatGuid(evt.chatGuid),
+              cursor,
             };
           } else if (proto.messageReceived !== undefined) {
             const evt: MessageReceivedEvent = proto.messageReceived;
@@ -577,6 +619,7 @@ export class MessagesResource {
               timestamp,
               message: mapMessage(unwrap(evt.message, "message")),
               chatGuid: chatGuid(evt.chatGuid),
+              cursor,
             };
           } else if (proto.messageUpdated !== undefined) {
             const evt: MessageUpdatedEvent = proto.messageUpdated;
@@ -590,6 +633,7 @@ export class MessagesResource {
                 | "notified"
                 | "reaction",
               chatGuid: chatGuid(evt.chatGuid),
+              cursor,
             };
           } else if (proto.messageSendError !== undefined) {
             const evt: MessageSendErrorEvent = proto.messageSendError;
@@ -600,6 +644,7 @@ export class MessagesResource {
               clientMessageId: evt.clientMessageId,
               errorCode: evt.errorCode,
               errorMessage: evt.errorMessage,
+              cursor,
             };
           }
           // Unknown payload kinds are silently skipped.

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -25,12 +25,14 @@ export type MessageEvent =
       readonly message: Message;
       readonly clientMessageId?: string;
       readonly chatGuid: ChatGuid;
+      readonly cursor?: string;
     }
   | {
       readonly type: "message.received";
       readonly timestamp: Date;
       readonly message: Message;
       readonly chatGuid: ChatGuid;
+      readonly cursor?: string;
     }
   | {
       readonly type: "message.updated";
@@ -38,6 +40,7 @@ export type MessageEvent =
       readonly message: Message;
       readonly updateType: "edited" | "unsent" | "notified" | "reaction";
       readonly chatGuid: ChatGuid;
+      readonly cursor?: string;
     }
   | {
       readonly type: "message.sendError";
@@ -46,6 +49,7 @@ export type MessageEvent =
       readonly clientMessageId?: string;
       readonly errorCode: string;
       readonly errorMessage: string;
+      readonly cursor?: string;
     };
 
 // ---------------------------------------------------------------------------

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -241,6 +241,13 @@ export interface ComposedMessage {
 export interface MessageListOptions {
   /** Return only messages created after this date. */
   readonly after?: Date;
+  /**
+   * Resume cursor from a stream event. When set, returns messages with
+   * ROWID > cursor position, overriding `after`.
+   * Sort is forced to ascending by ROWID (chronological order for catch-up).
+   * `offset` and `limit` still apply for pagination within catch-up results.
+   */
+  readonly afterCursor?: string;
   /** Return only messages created before this date. */
   readonly before?: Date;
   /** Restrict to messages in a specific chat. */
@@ -255,6 +262,18 @@ export interface MessageListOptions {
   readonly withAttachments?: boolean;
   /** Include chat metadata in the response. */
   readonly withChats?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// FetchMissedOptions
+// ---------------------------------------------------------------------------
+
+/** Options for `messages.fetchMissed()`. */
+export interface FetchMissedOptions {
+  /** Restrict to messages in a specific chat. */
+  readonly chatGuid?: ChatGuid;
+  /** Maximum number of messages per page. */
+  readonly limit?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add cursor-based stream catch-up so SDK users can recover missed messages after a disconnect with 3 lines of code.

- `subscribe()` events now carry an opaque `cursor` string
- `fetchMissed(cursor)` fetches all messages after the cursor position, ordered chronologically, with full chat + attachment metadata
- `list({ afterCursor })` is the low-level API for cursor-based queries
- Proto doc comments added across all services for better DX
- DESIGN.md updated with Stream Catch-Up section and usage example

### Usage

```ts
let cursor = loadPersistedCursor();

// 1. Catch up on missed messages
if (cursor) {
  for await (const msg of im.messages.fetchMissed(cursor)) {
    processMissedMessage(msg);
  }
}

// 2. Resume live stream, tracking cursor
for await (const event of im.messages.subscribe()) {
  if (event.cursor) cursor = event.cursor;
  processEvent(event);
}
```

## Test plan

- [x] `bun test` — 29 tests pass
- [x] E2E: subscribe collects cursors with correct format (`msg:<rowid>`)
- [x] E2E: fetchMissed returns messages in chronological order
- [x] E2E: fetchMissed auto-paginates via for-await
- [x] E2E: fetchMissed with chatGuid filter works
- [x] E2E: invalid cursors (`msg:0`, `msg:-1`, `msg:`, `invalid`) throw
- [x] E2E: empty string cursor treated as no-cursor (JS falsy)
- [x] E2E: cursor beyond max ROWID → 0 results
- [x] E2E: disconnect 10s → fetchMissed → re-subscribe → zero message loss, zero overlap, 29ms recovery, 236ms first live event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added message stream cursor support for automatic catch-up after connection loss
- New `fetchMissed()` method retrieves messages from a specific point in the stream  
- Message events now include cursor information for maintaining stream continuity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->