### PR TITLE
refactor: remove unused CursorReset proto message

### DIFF
--- a/proto/photon/imessage/v1/common.proto
+++ b/proto/photon/imessage/v1/common.proto
@@ -26,10 +26,3 @@ enum SortDirection {
 message StreamCursor {
   string value = 1;
 }
-
-// Sent when a client's cursor is no longer valid (e.g. server reinstalled,
-// chat.db reset). The client should discard its stored cursor and optionally
-// use ListMessages to catch up.
-message CursorReset {
-  StreamCursor current_position = 1;
-}

--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -308,7 +308,6 @@ message SubscribeMessageEventsResponse {
     MessageReceivedEvent message_received = 11;
     MessageUpdatedEvent message_updated = 12;
     MessageSendErrorEvent message_send_error = 13;
-    CursorReset cursor_reset = 98;
     Heartbeat heartbeat = 99;
   }
 }

--- a/src/generated/photon/imessage/v1/common.ts
+++ b/src/generated/photon/imessage/v1/common.ts
@@ -71,15 +71,6 @@ export interface StreamCursor {
   value: string;
 }
 
-/**
- * Sent when a client's cursor is no longer valid (e.g. server reinstalled,
- * chat.db reset). The client should discard its stored cursor and optionally
- * use ListMessages to catch up.
- */
-export interface CursorReset {
-  currentPosition: StreamCursor | undefined;
-}
-
 function createBasePaginatedMeta(): PaginatedMeta {
   return { total: 0, offset: 0, limit: 0 };
 }
@@ -269,72 +260,6 @@ export const StreamCursor: MessageFns<StreamCursor> = {
   fromPartial(object: DeepPartial<StreamCursor>): StreamCursor {
     const message = createBaseStreamCursor();
     message.value = object.value ?? "";
-    return message;
-  },
-};
-
-function createBaseCursorReset(): CursorReset {
-  return { currentPosition: undefined };
-}
-
-export const CursorReset: MessageFns<CursorReset> = {
-  encode(message: CursorReset, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.currentPosition !== undefined) {
-      StreamCursor.encode(message.currentPosition, writer.uint32(10).fork()).join();
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): CursorReset {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseCursorReset();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.currentPosition = StreamCursor.decode(reader, reader.uint32());
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): CursorReset {
-    return {
-      currentPosition: isSet(object.currentPosition)
-        ? StreamCursor.fromJSON(object.currentPosition)
-        : isSet(object.current_position)
-        ? StreamCursor.fromJSON(object.current_position)
-        : undefined,
-    };
-  },
-
-  toJSON(message: CursorReset): unknown {
-    const obj: any = {};
-    if (message.currentPosition !== undefined) {
-      obj.currentPosition = StreamCursor.toJSON(message.currentPosition);
-    }
-    return obj;
-  },
-
-  create(base?: DeepPartial<CursorReset>): CursorReset {
-    return CursorReset.fromPartial(base ?? {});
-  },
-  fromPartial(object: DeepPartial<CursorReset>): CursorReset {
-    const message = createBaseCursorReset();
-    message.currentPosition = (object.currentPosition !== undefined && object.currentPosition !== null)
-      ? StreamCursor.fromPartial(object.currentPosition)
-      : undefined;
     return message;
   },
 };

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -9,7 +9,6 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
 import {
-  CursorReset,
   Heartbeat,
   PaginatedMeta,
   SortDirection,
@@ -386,7 +385,6 @@ export interface SubscribeMessageEventsResponse {
   messageReceived?: MessageReceivedEvent | undefined;
   messageUpdated?: MessageUpdatedEvent | undefined;
   messageSendError?: MessageSendErrorEvent | undefined;
-  cursorReset?: CursorReset | undefined;
   heartbeat?: Heartbeat | undefined;
 }
 
@@ -4449,7 +4447,6 @@ function createBaseSubscribeMessageEventsResponse(): SubscribeMessageEventsRespo
     messageReceived: undefined,
     messageUpdated: undefined,
     messageSendError: undefined,
-    cursorReset: undefined,
     heartbeat: undefined,
   };
 }
@@ -4473,9 +4470,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageSendError !== undefined) {
       MessageSendErrorEvent.encode(message.messageSendError, writer.uint32(106).fork()).join();
-    }
-    if (message.cursorReset !== undefined) {
-      CursorReset.encode(message.cursorReset, writer.uint32(786).fork()).join();
     }
     if (message.heartbeat !== undefined) {
       Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
@@ -4538,14 +4532,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
           message.messageSendError = MessageSendErrorEvent.decode(reader, reader.uint32());
           continue;
         }
-        case 98: {
-          if (tag !== 786) {
-            break;
-          }
-
-          message.cursorReset = CursorReset.decode(reader, reader.uint32());
-          continue;
-        }
         case 99: {
           if (tag !== 794) {
             break;
@@ -4587,11 +4573,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
         : isSet(object.message_send_error)
         ? MessageSendErrorEvent.fromJSON(object.message_send_error)
         : undefined,
-      cursorReset: isSet(object.cursorReset)
-        ? CursorReset.fromJSON(object.cursorReset)
-        : isSet(object.cursor_reset)
-        ? CursorReset.fromJSON(object.cursor_reset)
-        : undefined,
       heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
@@ -4615,9 +4596,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageSendError !== undefined) {
       obj.messageSendError = MessageSendErrorEvent.toJSON(message.messageSendError);
-    }
-    if (message.cursorReset !== undefined) {
-      obj.cursorReset = CursorReset.toJSON(message.cursorReset);
     }
     if (message.heartbeat !== undefined) {
       obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
@@ -4645,9 +4623,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
       : undefined;
     message.messageSendError = (object.messageSendError !== undefined && object.messageSendError !== null)
       ? MessageSendErrorEvent.fromPartial(object.messageSendError)
-      : undefined;
-    message.cursorReset = (object.cursorReset !== undefined && object.cursorReset !== null)
-      ? CursorReset.fromPartial(object.cursorReset)
       : undefined;
     message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
       ? Heartbeat.fromPartial(object.heartbeat)


### PR DESCRIPTION
## Summary

- Remove `CursorReset` message from `common.proto` and `cursor_reset` field from `SubscribeMessageEventsResponse` oneof in `message_service.proto`.
- Regenerate TypeScript protobuf code.
- No SDK source changes needed — the SDK already skipped unknown payload kinds.

## Changed files

| File | Change |
|------|--------|
| `proto/photon/imessage/v1/common.proto` | Remove `CursorReset` message |
| `proto/photon/imessage/v1/message_service.proto` | Remove `cursor_reset` from oneof |
| `src/generated/photon/imessage/v1/common.ts` | Regenerated |
| `src/generated/photon/imessage/v1/message_service.ts` | Regenerated |

## Test plan

- [ ] `bun run build` passes
- [ ] Cursor catch-up feature intact (`afterCursor`, `fetchMissed`, `cursor` on events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed cursor reset event type from message subscriptions
  * Updated backend service dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->