### PR TITLE
docs: add JSDoc comments to ClientOptions and createClient

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -17,12 +17,19 @@ import { ScheduledMessagesResource as ScheduledMessagesImpl } from "./resources/
 import { createGrpcClients } from "./transport/grpc-client.js";
 import type { RetryOptions } from "./types/common.js";
 
+/** Options for configuring the Advanced iMessage client. */
 export interface ClientOptions {
+  /** The server address to connect to (e.g., `"localhost:50051"`). */
   readonly address: string;
+  /** When `true`, automatically generates a unique key for each request to prevent duplicate operations. */
   readonly autoIdempotency?: boolean;
+  /** When `true`, enables automatic retries. Accepts a {@link RetryOptions} object for fine-grained control. */
   readonly retry?: boolean | RetryOptions;
+  /** Request timeout in milliseconds. */
   readonly timeout?: number;
+  /** When `true`, uses a TLS-encrypted connection to the server. */
   readonly tls?: boolean;
+  /** Authentication token. Pass a function that returns `Promise<string>` to provide the token dynamically. */
   readonly token: string | (() => Promise<string>);
 }
 
@@ -38,6 +45,23 @@ export interface AdvancedIMessage extends AsyncDisposable {
   readonly scheduledMessages: ScheduledMessagesResource;
 }
 
+/**
+ * Creates an Advanced iMessage client with access to messages, chats, groups, attachments, polls, and more.
+ *
+ * Call {@link AdvancedIMessage.close} to release the underlying connection when done.
+ *
+ * @example
+ * ```ts
+ * const im = createClient({
+ *   address: "localhost:50051",
+ *   token: "my-api-token",
+ * });
+ *
+ * // ... use im.messages, im.groups, etc.
+ *
+ * await im.close();
+ * ```
+ */
 export function createClient(options: ClientOptions): AdvancedIMessage {
   const clients = createGrpcClients({
     address: options.address,


### PR DESCRIPTION
## Summary

- Add JSDoc comments to the `ClientOptions` interface, documenting each option (`address`, `autoIdempotency`, `retry`, `timeout`, `tls`, `token`)
- Add JSDoc to the `createClient` function with a usage example

## Motivation

The generated API docs show an empty "Description" column for every `ClientOptions` field. These JSDoc comments populate those descriptions so users can understand each option without reading source code.

## Test plan

- [ ] Verify JSDoc renders correctly in IDE hover tooltips
- [ ] Verify generated docs site shows descriptions in the table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced client configuration documentation with detailed guidance on auto-idempotency, retry, timeout, and TLS settings.
  * Added usage examples for client initialization and proper resource cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->