### PR TITLE
Refactor/message event stream v2

### DIFF
--- a/.claude/skills/typescript-sdk-dx/references/patterns.md
+++ b/.claude/skills/typescript-sdk-dx/references/patterns.md
@@ -95,8 +95,7 @@ Factory function `fromGrpcError()` lives in transport layer. Resources never con
 type MessageEvent =
   | { type: "message.sent"; message: Message; chatGuid: ChatGuid }
   | { type: "message.received"; message: Message; chatGuid: ChatGuid }
-  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" }
-  | { type: "message.sendError"; errorCode: string; errorMessage: string };
+  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction" };
 ```
 
 `subscribe()` overloaded to narrow:

--- a/.claude/skills/typescript-sdk-dx/references/patterns.md
+++ b/.claude/skills/typescript-sdk-dx/references/patterns.md
@@ -95,7 +95,7 @@ Factory function `fromGrpcError()` lives in transport layer. Resources never con
 type MessageEvent =
   | { type: "message.sent"; message: Message; chatGuid: ChatGuid }
   | { type: "message.received"; message: Message; chatGuid: ChatGuid }
-  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction" };
+  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction"; chatGuid: ChatGuid };
 ```
 
 `subscribe()` overloaded to narrow:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,7 +140,7 @@ No pagination API to learn. Standard JS iteration handles it.
 type MessageEvent =
   | { type: "message.sent"; message: Message; chatGuid: ChatGuid; cursor?: string }
   | { type: "message.received"; message: Message; chatGuid: ChatGuid; cursor?: string }
-  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction"; cursor?: string };
+  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction"; chatGuid: ChatGuid; cursor?: string };
 ```
 
 Each event carries an opaque `cursor` — a position marker for catching up after a disconnect. See [Stream Catch-Up](#stream-catch-up) below.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,8 +140,7 @@ No pagination API to learn. Standard JS iteration handles it.
 type MessageEvent =
   | { type: "message.sent"; message: Message; chatGuid: ChatGuid; cursor?: string }
   | { type: "message.received"; message: Message; chatGuid: ChatGuid; cursor?: string }
-  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction"; cursor?: string }
-  | { type: "message.sendError"; errorCode: string; errorMessage: string; cursor?: string };
+  | { type: "message.updated"; message: Message; updateType: "edited" | "unsent" | "notified" | "reaction"; cursor?: string };
 ```
 
 Each event carries an opaque `cursor` — a position marker for catching up after a disconnect. See [Stream Catch-Up](#stream-catch-up) below.

--- a/proto/photon/imessage/v1/location_service.proto
+++ b/proto/photon/imessage/v1/location_service.proto
@@ -4,6 +4,7 @@ package photon.imessage.v1;
 option swift_prefix = "PIMsg_";
 
 import "google/protobuf/timestamp.proto";
+import "photon/imessage/v1/common.proto";
 
 // ---------------------------------------------------------------------------
 // Service
@@ -66,6 +67,7 @@ message SubscribeLocationEventsResponse {
   google.protobuf.Timestamp timestamp = 1;
   oneof payload {
     FindMyEvent find_my_location_updated = 10;
+    Heartbeat heartbeat = 99;
   }
 }
 

--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -311,6 +311,7 @@ message SubscribeMessageEventsResponse {
     Heartbeat heartbeat = 99;
   }
   reserved 13;
+  reserved "message_send_error";
 }
 
 message MessageSentEvent {

--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -307,9 +307,10 @@ message SubscribeMessageEventsResponse {
     MessageSentEvent message_sent = 10;
     MessageReceivedEvent message_received = 11;
     MessageUpdatedEvent message_updated = 12;
-    MessageSendErrorEvent message_send_error = 13;
+    // Field 13 (message_send_error) removed — send errors are returned via RPC, not the event stream.
     Heartbeat heartbeat = 99;
   }
+  reserved 13;
 }
 
 message MessageSentEvent {
@@ -329,9 +330,5 @@ message MessageUpdatedEvent {
   string chat_guid = 3;
 }
 
-message MessageSendErrorEvent {
-  string chat_guid = 1;
-  optional string client_message_id = 2;
-  string error_code = 3;
-  string error_message = 4;
-}
+// MessageSendErrorEvent removed — send errors are returned synchronously via the
+// Send RPC's gRPC error status; they do not appear in the event stream.

--- a/proto/photon/imessage/v1/poll_service.proto
+++ b/proto/photon/imessage/v1/poll_service.proto
@@ -108,9 +108,17 @@ message SubscribePollEventsResponse {
   }
 }
 
+enum PollAction {
+  POLL_ACTION_UNSPECIFIED = 0;
+  POLL_ACTION_CREATED = 1;
+  POLL_ACTION_VOTED = 2;
+  POLL_ACTION_UNVOTED = 3;
+  POLL_ACTION_OPTION_ADDED = 4;
+}
+
 message PollChangeEvent {
   string chat_guid = 1;
   string poll_message_guid = 2;
   Message message = 3;
-  string action = 4;
+  PollAction action = 4;
 }

--- a/src/generated/photon/imessage/v1/location_service.ts
+++ b/src/generated/photon/imessage/v1/location_service.ts
@@ -8,6 +8,7 @@
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
+import { Heartbeat } from "./common.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
@@ -85,6 +86,7 @@ export interface SubscribeLocationEventsRequest {
 export interface SubscribeLocationEventsResponse {
   timestamp: Date | undefined;
   findMyLocationUpdated?: FindMyEvent | undefined;
+  heartbeat?: Heartbeat | undefined;
 }
 
 export interface FindMyEvent {
@@ -517,7 +519,7 @@ export const SubscribeLocationEventsRequest: MessageFns<SubscribeLocationEventsR
 };
 
 function createBaseSubscribeLocationEventsResponse(): SubscribeLocationEventsResponse {
-  return { timestamp: undefined, findMyLocationUpdated: undefined };
+  return { timestamp: undefined, findMyLocationUpdated: undefined, heartbeat: undefined };
 }
 
 export const SubscribeLocationEventsResponse: MessageFns<SubscribeLocationEventsResponse> = {
@@ -527,6 +529,9 @@ export const SubscribeLocationEventsResponse: MessageFns<SubscribeLocationEvents
     }
     if (message.findMyLocationUpdated !== undefined) {
       FindMyEvent.encode(message.findMyLocationUpdated, writer.uint32(82).fork()).join();
+    }
+    if (message.heartbeat !== undefined) {
+      Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
     }
     return writer;
   },
@@ -554,6 +559,14 @@ export const SubscribeLocationEventsResponse: MessageFns<SubscribeLocationEvents
           message.findMyLocationUpdated = FindMyEvent.decode(reader, reader.uint32());
           continue;
         }
+        case 99: {
+          if (tag !== 794) {
+            break;
+          }
+
+          message.heartbeat = Heartbeat.decode(reader, reader.uint32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -571,6 +584,7 @@ export const SubscribeLocationEventsResponse: MessageFns<SubscribeLocationEvents
         : isSet(object.find_my_location_updated)
         ? FindMyEvent.fromJSON(object.find_my_location_updated)
         : undefined,
+      heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
 
@@ -581,6 +595,9 @@ export const SubscribeLocationEventsResponse: MessageFns<SubscribeLocationEvents
     }
     if (message.findMyLocationUpdated !== undefined) {
       obj.findMyLocationUpdated = FindMyEvent.toJSON(message.findMyLocationUpdated);
+    }
+    if (message.heartbeat !== undefined) {
+      obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
     }
     return obj;
   },
@@ -595,6 +612,9 @@ export const SubscribeLocationEventsResponse: MessageFns<SubscribeLocationEvents
       (object.findMyLocationUpdated !== undefined && object.findMyLocationUpdated !== null)
         ? FindMyEvent.fromPartial(object.findMyLocationUpdated)
         : undefined;
+    message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
+      ? Heartbeat.fromPartial(object.heartbeat)
+      : undefined;
     return message;
   },
 };

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -383,8 +383,10 @@ export interface SubscribeMessageEventsResponse {
   cursor?: StreamCursor | undefined;
   messageSent?: MessageSentEvent | undefined;
   messageReceived?: MessageReceivedEvent | undefined;
-  messageUpdated?: MessageUpdatedEvent | undefined;
-  messageSendError?: MessageSendErrorEvent | undefined;
+  messageUpdated?:
+    | MessageUpdatedEvent
+    | undefined;
+  /** Field 13 (message_send_error) removed — send errors are returned via RPC, not the event stream. */
   heartbeat?: Heartbeat | undefined;
 }
 
@@ -403,13 +405,6 @@ export interface MessageUpdatedEvent {
   message: Message | undefined;
   updateType: string;
   chatGuid: string;
-}
-
-export interface MessageSendErrorEvent {
-  chatGuid: string;
-  clientMessageId?: string | undefined;
-  errorCode: string;
-  errorMessage: string;
 }
 
 function createBaseAddressInfo(): AddressInfo {
@@ -4446,7 +4441,6 @@ function createBaseSubscribeMessageEventsResponse(): SubscribeMessageEventsRespo
     messageSent: undefined,
     messageReceived: undefined,
     messageUpdated: undefined,
-    messageSendError: undefined,
     heartbeat: undefined,
   };
 }
@@ -4467,9 +4461,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageUpdated !== undefined) {
       MessageUpdatedEvent.encode(message.messageUpdated, writer.uint32(98).fork()).join();
-    }
-    if (message.messageSendError !== undefined) {
-      MessageSendErrorEvent.encode(message.messageSendError, writer.uint32(106).fork()).join();
     }
     if (message.heartbeat !== undefined) {
       Heartbeat.encode(message.heartbeat, writer.uint32(794).fork()).join();
@@ -4524,14 +4515,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
           message.messageUpdated = MessageUpdatedEvent.decode(reader, reader.uint32());
           continue;
         }
-        case 13: {
-          if (tag !== 106) {
-            break;
-          }
-
-          message.messageSendError = MessageSendErrorEvent.decode(reader, reader.uint32());
-          continue;
-        }
         case 99: {
           if (tag !== 794) {
             break;
@@ -4568,11 +4551,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
         : isSet(object.message_updated)
         ? MessageUpdatedEvent.fromJSON(object.message_updated)
         : undefined,
-      messageSendError: isSet(object.messageSendError)
-        ? MessageSendErrorEvent.fromJSON(object.messageSendError)
-        : isSet(object.message_send_error)
-        ? MessageSendErrorEvent.fromJSON(object.message_send_error)
-        : undefined,
       heartbeat: isSet(object.heartbeat) ? Heartbeat.fromJSON(object.heartbeat) : undefined,
     };
   },
@@ -4593,9 +4571,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
     }
     if (message.messageUpdated !== undefined) {
       obj.messageUpdated = MessageUpdatedEvent.toJSON(message.messageUpdated);
-    }
-    if (message.messageSendError !== undefined) {
-      obj.messageSendError = MessageSendErrorEvent.toJSON(message.messageSendError);
     }
     if (message.heartbeat !== undefined) {
       obj.heartbeat = Heartbeat.toJSON(message.heartbeat);
@@ -4620,9 +4595,6 @@ export const SubscribeMessageEventsResponse: MessageFns<SubscribeMessageEventsRe
       : undefined;
     message.messageUpdated = (object.messageUpdated !== undefined && object.messageUpdated !== null)
       ? MessageUpdatedEvent.fromPartial(object.messageUpdated)
-      : undefined;
-    message.messageSendError = (object.messageSendError !== undefined && object.messageSendError !== null)
-      ? MessageSendErrorEvent.fromPartial(object.messageSendError)
       : undefined;
     message.heartbeat = (object.heartbeat !== undefined && object.heartbeat !== null)
       ? Heartbeat.fromPartial(object.heartbeat)
@@ -4913,130 +4885,6 @@ export const MessageUpdatedEvent: MessageFns<MessageUpdatedEvent> = {
       : undefined;
     message.updateType = object.updateType ?? "";
     message.chatGuid = object.chatGuid ?? "";
-    return message;
-  },
-};
-
-function createBaseMessageSendErrorEvent(): MessageSendErrorEvent {
-  return { chatGuid: "", clientMessageId: undefined, errorCode: "", errorMessage: "" };
-}
-
-export const MessageSendErrorEvent: MessageFns<MessageSendErrorEvent> = {
-  encode(message: MessageSendErrorEvent, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatGuid !== "") {
-      writer.uint32(10).string(message.chatGuid);
-    }
-    if (message.clientMessageId !== undefined) {
-      writer.uint32(18).string(message.clientMessageId);
-    }
-    if (message.errorCode !== "") {
-      writer.uint32(26).string(message.errorCode);
-    }
-    if (message.errorMessage !== "") {
-      writer.uint32(34).string(message.errorMessage);
-    }
-    return writer;
-  },
-
-  decode(input: BinaryReader | Uint8Array, length?: number): MessageSendErrorEvent {
-    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
-    const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseMessageSendErrorEvent();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.chatGuid = reader.string();
-          continue;
-        }
-        case 2: {
-          if (tag !== 18) {
-            break;
-          }
-
-          message.clientMessageId = reader.string();
-          continue;
-        }
-        case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.errorCode = reader.string();
-          continue;
-        }
-        case 4: {
-          if (tag !== 34) {
-            break;
-          }
-
-          message.errorMessage = reader.string();
-          continue;
-        }
-      }
-      if ((tag & 7) === 4 || tag === 0) {
-        break;
-      }
-      reader.skip(tag & 7);
-    }
-    return message;
-  },
-
-  fromJSON(object: any): MessageSendErrorEvent {
-    return {
-      chatGuid: isSet(object.chatGuid)
-        ? globalThis.String(object.chatGuid)
-        : isSet(object.chat_guid)
-        ? globalThis.String(object.chat_guid)
-        : "",
-      clientMessageId: isSet(object.clientMessageId)
-        ? globalThis.String(object.clientMessageId)
-        : isSet(object.client_message_id)
-        ? globalThis.String(object.client_message_id)
-        : undefined,
-      errorCode: isSet(object.errorCode)
-        ? globalThis.String(object.errorCode)
-        : isSet(object.error_code)
-        ? globalThis.String(object.error_code)
-        : "",
-      errorMessage: isSet(object.errorMessage)
-        ? globalThis.String(object.errorMessage)
-        : isSet(object.error_message)
-        ? globalThis.String(object.error_message)
-        : "",
-    };
-  },
-
-  toJSON(message: MessageSendErrorEvent): unknown {
-    const obj: any = {};
-    if (message.chatGuid !== "") {
-      obj.chatGuid = message.chatGuid;
-    }
-    if (message.clientMessageId !== undefined) {
-      obj.clientMessageId = message.clientMessageId;
-    }
-    if (message.errorCode !== "") {
-      obj.errorCode = message.errorCode;
-    }
-    if (message.errorMessage !== "") {
-      obj.errorMessage = message.errorMessage;
-    }
-    return obj;
-  },
-
-  create(base?: DeepPartial<MessageSendErrorEvent>): MessageSendErrorEvent {
-    return MessageSendErrorEvent.fromPartial(base ?? {});
-  },
-  fromPartial(object: DeepPartial<MessageSendErrorEvent>): MessageSendErrorEvent {
-    const message = createBaseMessageSendErrorEvent();
-    message.chatGuid = object.chatGuid ?? "";
-    message.clientMessageId = object.clientMessageId ?? undefined;
-    message.errorCode = object.errorCode ?? "";
-    message.errorMessage = object.errorMessage ?? "";
     return message;
   },
 };

--- a/src/generated/photon/imessage/v1/poll_service.ts
+++ b/src/generated/photon/imessage/v1/poll_service.ts
@@ -13,6 +13,57 @@ import { Message, MessageCommandReceipt } from "./message_service.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
+export enum PollAction {
+  POLL_ACTION_UNSPECIFIED = 0,
+  POLL_ACTION_CREATED = 1,
+  POLL_ACTION_VOTED = 2,
+  POLL_ACTION_UNVOTED = 3,
+  POLL_ACTION_OPTION_ADDED = 4,
+  UNRECOGNIZED = -1,
+}
+
+export function pollActionFromJSON(object: any): PollAction {
+  switch (object) {
+    case 0:
+    case "POLL_ACTION_UNSPECIFIED":
+      return PollAction.POLL_ACTION_UNSPECIFIED;
+    case 1:
+    case "POLL_ACTION_CREATED":
+      return PollAction.POLL_ACTION_CREATED;
+    case 2:
+    case "POLL_ACTION_VOTED":
+      return PollAction.POLL_ACTION_VOTED;
+    case 3:
+    case "POLL_ACTION_UNVOTED":
+      return PollAction.POLL_ACTION_UNVOTED;
+    case 4:
+    case "POLL_ACTION_OPTION_ADDED":
+      return PollAction.POLL_ACTION_OPTION_ADDED;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return PollAction.UNRECOGNIZED;
+  }
+}
+
+export function pollActionToJSON(object: PollAction): string {
+  switch (object) {
+    case PollAction.POLL_ACTION_UNSPECIFIED:
+      return "POLL_ACTION_UNSPECIFIED";
+    case PollAction.POLL_ACTION_CREATED:
+      return "POLL_ACTION_CREATED";
+    case PollAction.POLL_ACTION_VOTED:
+      return "POLL_ACTION_VOTED";
+    case PollAction.POLL_ACTION_UNVOTED:
+      return "POLL_ACTION_UNVOTED";
+    case PollAction.POLL_ACTION_OPTION_ADDED:
+      return "POLL_ACTION_OPTION_ADDED";
+    case PollAction.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
 export interface PollOption {
   text: string;
   optionIdentifier?: string | undefined;
@@ -92,7 +143,7 @@ export interface PollChangeEvent {
   chatGuid: string;
   pollMessageGuid: string;
   message: Message | undefined;
-  action: string;
+  action: PollAction;
 }
 
 function createBasePollOption(): PollOption {
@@ -1305,7 +1356,7 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
 };
 
 function createBasePollChangeEvent(): PollChangeEvent {
-  return { chatGuid: "", pollMessageGuid: "", message: undefined, action: "" };
+  return { chatGuid: "", pollMessageGuid: "", message: undefined, action: 0 };
 }
 
 export const PollChangeEvent: MessageFns<PollChangeEvent> = {
@@ -1319,8 +1370,8 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
     if (message.message !== undefined) {
       Message.encode(message.message, writer.uint32(26).fork()).join();
     }
-    if (message.action !== "") {
-      writer.uint32(34).string(message.action);
+    if (message.action !== 0) {
+      writer.uint32(32).int32(message.action);
     }
     return writer;
   },
@@ -1357,11 +1408,11 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
           continue;
         }
         case 4: {
-          if (tag !== 34) {
+          if (tag !== 32) {
             break;
           }
 
-          message.action = reader.string();
+          message.action = reader.int32() as any;
           continue;
         }
       }
@@ -1386,7 +1437,7 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
         ? globalThis.String(object.poll_message_guid)
         : "",
       message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
-      action: isSet(object.action) ? globalThis.String(object.action) : "",
+      action: isSet(object.action) ? pollActionFromJSON(object.action) : 0,
     };
   },
 
@@ -1401,8 +1452,8 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
     if (message.message !== undefined) {
       obj.message = Message.toJSON(message.message);
     }
-    if (message.action !== "") {
-      obj.action = message.action;
+    if (message.action !== 0) {
+      obj.action = pollActionToJSON(message.action);
     }
     return obj;
   },
@@ -1417,7 +1468,7 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
     message.message = (object.message !== undefined && object.message !== null)
       ? Message.fromPartial(object.message)
       : undefined;
-    message.action = object.action ?? "";
+    message.action = object.action ?? 0;
     return message;
   },
 };

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -8,7 +8,6 @@ import { fromGrpcError } from "../errors/error-handler.ts";
 import { SortDirection as ProtoSortDirection } from "../generated/photon/imessage/v1/common.ts";
 import type {
   MessageReceivedEvent,
-  MessageSendErrorEvent,
   MessageSentEvent,
   MessageUpdatedEvent,
   MessagePart as ProtoMessagePart,
@@ -635,19 +634,8 @@ export class MessagesResource {
               chatGuid: chatGuid(evt.chatGuid),
               cursor,
             };
-          } else if (proto.messageSendError !== undefined) {
-            const evt: MessageSendErrorEvent = proto.messageSendError;
-            yield {
-              type: "message.sendError" as const,
-              timestamp,
-              chatGuid: chatGuid(evt.chatGuid),
-              clientMessageId: evt.clientMessageId,
-              errorCode: evt.errorCode,
-              errorMessage: evt.errorMessage,
-              cursor,
-            };
           }
-          // Unknown payload kinds are silently skipped.
+          // Unknown payload kinds (including heartbeat) are silently skipped.
         }
       } catch (err) {
         throw fromGrpcError(err);

--- a/src/resources/polls.ts
+++ b/src/resources/polls.ts
@@ -6,7 +6,10 @@
  */
 
 import { fromGrpcError } from "../errors/error-handler.ts";
-import type { PollChangeEvent } from "../generated/photon/imessage/v1/poll_service.ts";
+import {
+  PollAction,
+  type PollChangeEvent,
+} from "../generated/photon/imessage/v1/poll_service.ts";
 import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { PollServiceClient } from "../transport/grpc-client.ts";
 import { mapMessage, mapPollInfo } from "../transport/mapper.ts";
@@ -160,20 +163,19 @@ export class PollsResource {
 // ---------------------------------------------------------------------------
 
 /**
- * Map a proto poll action string to the SDK PollEvent action literal.
+ * Map a proto PollAction enum to the SDK PollEvent action literal.
  */
 function mapPollAction(
-  action: string
+  action: PollAction
 ): "created" | "voted" | "unvoted" | "optionAdded" {
   switch (action) {
-    case "created":
+    case PollAction.POLL_ACTION_CREATED:
       return "created";
-    case "voted":
+    case PollAction.POLL_ACTION_VOTED:
       return "voted";
-    case "unvoted":
+    case PollAction.POLL_ACTION_UNVOTED:
       return "unvoted";
-    case "optionAdded":
-    case "option_added":
+    case PollAction.POLL_ACTION_OPTION_ADDED:
       return "optionAdded";
     default:
       return "created";

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -40,15 +40,6 @@ export type MessageEvent =
       readonly updateType: "edited" | "unsent" | "notified" | "reaction";
       readonly chatGuid: ChatGuid;
       readonly cursor?: string;
-    }
-  | {
-      readonly type: "message.sendError";
-      readonly timestamp: Date;
-      readonly chatGuid: ChatGuid;
-      readonly clientMessageId?: string;
-      readonly errorCode: string;
-      readonly errorMessage: string;
-      readonly cursor?: string;
     };
 
 // ---------------------------------------------------------------------------
@@ -165,7 +156,6 @@ export interface EventTypeMap {
   "group.changed": GroupEvent;
   "location.updated": LocationEvent;
   "message.received": Extract<MessageEvent, { type: "message.received" }>;
-  "message.sendError": Extract<MessageEvent, { type: "message.sendError" }>;
   "message.sent": Extract<MessageEvent, { type: "message.sent" }>;
   "message.updated": Extract<MessageEvent, { type: "message.updated" }>;
   "poll.changed": PollEvent;


### PR DESCRIPTION
## Summary

Syncs the SDK with server-side proto and event stream changes:

- **Remove `MessageSendErrorEvent`**: Deleted from proto (field 13 reserved), generated code regenerated, `message.sendError` variant removed from `MessageEvent` union and `EventTypeMap`, handling branch removed from `MessagesResource.subscribe()`.
- **`PollAction` enum**: `PollChangeEvent.action` changed from `string` to `PollAction` enum in proto. `mapPollAction()` updated to switch on enum values instead of string literals.
- **Location heartbeat**: Added `Heartbeat heartbeat = 99` to `SubscribeLocationEventsResponse` oneof + `import common.proto`. No handler code change needed — `LocationsResource.subscribe()` already skips unknown payloads via `continue`.

No public API surface changes beyond the removal of the `"message.sendError"` event type.

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] `bun test` — 29 tests passed
- [x] Verified zero `sendError`/`MessageSendError` references in handwritten code
- [x] Verified proto structure matches server for all three changed messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message updated events now include "notified" and "reaction" update types and carry a chat identifier.
  * Location event stream now emits heartbeat messages.

* **Changes**
  * Message send errors are no longer delivered as streaming events and are surfaced via RPC error status.
  * Poll events now use a constrained enum for action values (stronger typing for created/voted/unvoted/optionAdded).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->