### PR TITLE
refactor(polls): adopt new poll change event shape (actor + delta)

### DIFF
--- a/proto/photon/imessage/v1/poll_service.proto
+++ b/proto/photon/imessage/v1/poll_service.proto
@@ -116,9 +116,75 @@ enum PollAction {
   POLL_ACTION_OPTION_ADDED = 4;
 }
 
+// ---------------------------------------------------------------------------
+// Poll change event
+// ---------------------------------------------------------------------------
+//
+// A self-contained snapshot of one poll change — no `getPoll` round-trip
+// required for common rendering. Clients switch on `action` (or on the
+// `delta` oneof) and read the matching payload.
+//
+// `actor` and `at` identify WHO made the change and WHEN. The per-action
+// payload carries the full post-change state (for `.created` / `.optionAdded`)
+// or the actor's current full selection (for `.voted`).
+//
+// Note on `.unvoted`: iMessage's vote protocol represents unvote as
+// "user cleared all their picks" — there is no per-option unvote. The
+// event therefore does not carry an option identifier. Use `getPoll` if
+// you need the full post-change tally.
+
+message PollActor {
+  // The handle address (email / phone) of the actor, if resolvable.
+  // Empty when the acting device is the local device (see `is_from_me`)
+  // or when the row carries no handle.
+  string address = 1;
+
+  // True when the change was written by the local iMessage account
+  // (self-initiated, including from another of the user's devices).
+  bool is_from_me = 2;
+}
+
+// Full initial poll state on creation.
+message PollCreated {
+  string title = 1;
+  repeated PollOption options = 2;
+}
+
+// Full post-change poll state after a definition update.
+// Currently the only observed Apple-side definition update is "option added",
+// but the payload carries the complete new state so the UI can render
+// any definition mutation without a follow-up query.
+message PollOptionAdded {
+  string title = 1;
+  repeated PollOption options = 2;
+}
+
+// Actor's current full selection after voting.
+// iMessage represents votes as the voter's current picks (not as deltas),
+// so `option_identifiers` is authoritative for this actor at this moment.
+message PollVoted {
+  repeated string option_identifiers = 1;
+}
+
+// Actor cleared all their votes. Carries no extra fields.
+message PollUnvoted {}
+
 message PollChangeEvent {
   string chat_guid = 1;
   string poll_message_guid = 2;
-  Message message = 3;
-  PollAction action = 4;
+  PollAction action = 3;
+
+  // When the change was written (the triggering message's dateCreated).
+  google.protobuf.Timestamp at = 4;
+
+  // Who made the change.
+  PollActor actor = 5;
+
+  // Per-action payload. The matching field is always set for a given action.
+  oneof delta {
+    PollCreated     created      = 10;
+    PollOptionAdded option_added = 11;
+    PollVoted       voted        = 12;
+    PollUnvoted     unvoted      = 13;
+  }
 }

--- a/src/generated/photon/imessage/v1/poll_service.ts
+++ b/src/generated/photon/imessage/v1/poll_service.ts
@@ -9,7 +9,7 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 import type { CallContext, CallOptions } from "nice-grpc-common";
 import { Timestamp } from "../../../google/protobuf/timestamp.js";
 import { Heartbeat } from "./common.js";
-import { Message, MessageCommandReceipt } from "./message_service.js";
+import { MessageCommandReceipt } from "./message_service.js";
 
 export const protobufPackage = "photon.imessage.v1";
 
@@ -139,11 +139,64 @@ export interface SubscribePollEventsResponse {
   heartbeat?: Heartbeat | undefined;
 }
 
+export interface PollActor {
+  /**
+   * The handle address (email / phone) of the actor, if resolvable.
+   * Empty when the acting device is the local device (see `is_from_me`)
+   * or when the row carries no handle.
+   */
+  address: string;
+  /**
+   * True when the change was written by the local iMessage account
+   * (self-initiated, including from another of the user's devices).
+   */
+  isFromMe: boolean;
+}
+
+/** Full initial poll state on creation. */
+export interface PollCreated {
+  title: string;
+  options: PollOption[];
+}
+
+/**
+ * Full post-change poll state after a definition update.
+ * Currently the only observed Apple-side definition update is "option added",
+ * but the payload carries the complete new state so the UI can render
+ * any definition mutation without a follow-up query.
+ */
+export interface PollOptionAdded {
+  title: string;
+  options: PollOption[];
+}
+
+/**
+ * Actor's current full selection after voting.
+ * iMessage represents votes as the voter's current picks (not as deltas),
+ * so `option_identifiers` is authoritative for this actor at this moment.
+ */
+export interface PollVoted {
+  optionIdentifiers: string[];
+}
+
+/** Actor cleared all their votes. Carries no extra fields. */
+export interface PollUnvoted {
+}
+
 export interface PollChangeEvent {
   chatGuid: string;
   pollMessageGuid: string;
-  message: Message | undefined;
   action: PollAction;
+  /** When the change was written (the triggering message's dateCreated). */
+  at:
+    | Date
+    | undefined;
+  /** Who made the change. */
+  actor: PollActor | undefined;
+  created?: PollCreated | undefined;
+  optionAdded?: PollOptionAdded | undefined;
+  voted?: PollVoted | undefined;
+  unvoted?: PollUnvoted | undefined;
 }
 
 function createBasePollOption(): PollOption {
@@ -1355,8 +1408,357 @@ export const SubscribePollEventsResponse: MessageFns<SubscribePollEventsResponse
   },
 };
 
+function createBasePollActor(): PollActor {
+  return { address: "", isFromMe: false };
+}
+
+export const PollActor: MessageFns<PollActor> = {
+  encode(message: PollActor, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (message.isFromMe !== false) {
+      writer.uint32(16).bool(message.isFromMe);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PollActor {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePollActor();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.address = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.isFromMe = reader.bool();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PollActor {
+    return {
+      address: isSet(object.address) ? globalThis.String(object.address) : "",
+      isFromMe: isSet(object.isFromMe)
+        ? globalThis.Boolean(object.isFromMe)
+        : isSet(object.is_from_me)
+        ? globalThis.Boolean(object.is_from_me)
+        : false,
+    };
+  },
+
+  toJSON(message: PollActor): unknown {
+    const obj: any = {};
+    if (message.address !== "") {
+      obj.address = message.address;
+    }
+    if (message.isFromMe !== false) {
+      obj.isFromMe = message.isFromMe;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<PollActor>): PollActor {
+    return PollActor.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PollActor>): PollActor {
+    const message = createBasePollActor();
+    message.address = object.address ?? "";
+    message.isFromMe = object.isFromMe ?? false;
+    return message;
+  },
+};
+
+function createBasePollCreated(): PollCreated {
+  return { title: "", options: [] };
+}
+
+export const PollCreated: MessageFns<PollCreated> = {
+  encode(message: PollCreated, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.title !== "") {
+      writer.uint32(10).string(message.title);
+    }
+    for (const v of message.options) {
+      PollOption.encode(v!, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PollCreated {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePollCreated();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.title = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.options.push(PollOption.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PollCreated {
+    return {
+      title: isSet(object.title) ? globalThis.String(object.title) : "",
+      options: globalThis.Array.isArray(object?.options) ? object.options.map((e: any) => PollOption.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: PollCreated): unknown {
+    const obj: any = {};
+    if (message.title !== "") {
+      obj.title = message.title;
+    }
+    if (message.options?.length) {
+      obj.options = message.options.map((e) => PollOption.toJSON(e));
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<PollCreated>): PollCreated {
+    return PollCreated.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PollCreated>): PollCreated {
+    const message = createBasePollCreated();
+    message.title = object.title ?? "";
+    message.options = object.options?.map((e) => PollOption.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBasePollOptionAdded(): PollOptionAdded {
+  return { title: "", options: [] };
+}
+
+export const PollOptionAdded: MessageFns<PollOptionAdded> = {
+  encode(message: PollOptionAdded, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.title !== "") {
+      writer.uint32(10).string(message.title);
+    }
+    for (const v of message.options) {
+      PollOption.encode(v!, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PollOptionAdded {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePollOptionAdded();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.title = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.options.push(PollOption.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PollOptionAdded {
+    return {
+      title: isSet(object.title) ? globalThis.String(object.title) : "",
+      options: globalThis.Array.isArray(object?.options) ? object.options.map((e: any) => PollOption.fromJSON(e)) : [],
+    };
+  },
+
+  toJSON(message: PollOptionAdded): unknown {
+    const obj: any = {};
+    if (message.title !== "") {
+      obj.title = message.title;
+    }
+    if (message.options?.length) {
+      obj.options = message.options.map((e) => PollOption.toJSON(e));
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<PollOptionAdded>): PollOptionAdded {
+    return PollOptionAdded.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PollOptionAdded>): PollOptionAdded {
+    const message = createBasePollOptionAdded();
+    message.title = object.title ?? "";
+    message.options = object.options?.map((e) => PollOption.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBasePollVoted(): PollVoted {
+  return { optionIdentifiers: [] };
+}
+
+export const PollVoted: MessageFns<PollVoted> = {
+  encode(message: PollVoted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.optionIdentifiers) {
+      writer.uint32(10).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PollVoted {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePollVoted();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.optionIdentifiers.push(reader.string());
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PollVoted {
+    return {
+      optionIdentifiers: globalThis.Array.isArray(object?.optionIdentifiers)
+        ? object.optionIdentifiers.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.option_identifiers)
+        ? object.option_identifiers.map((e: any) => globalThis.String(e))
+        : [],
+    };
+  },
+
+  toJSON(message: PollVoted): unknown {
+    const obj: any = {};
+    if (message.optionIdentifiers?.length) {
+      obj.optionIdentifiers = message.optionIdentifiers;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<PollVoted>): PollVoted {
+    return PollVoted.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<PollVoted>): PollVoted {
+    const message = createBasePollVoted();
+    message.optionIdentifiers = object.optionIdentifiers?.map((e) => e) || [];
+    return message;
+  },
+};
+
+function createBasePollUnvoted(): PollUnvoted {
+  return {};
+}
+
+export const PollUnvoted: MessageFns<PollUnvoted> = {
+  encode(_: PollUnvoted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): PollUnvoted {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePollUnvoted();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): PollUnvoted {
+    return {};
+  },
+
+  toJSON(_: PollUnvoted): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<PollUnvoted>): PollUnvoted {
+    return PollUnvoted.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<PollUnvoted>): PollUnvoted {
+    const message = createBasePollUnvoted();
+    return message;
+  },
+};
+
 function createBasePollChangeEvent(): PollChangeEvent {
-  return { chatGuid: "", pollMessageGuid: "", message: undefined, action: 0 };
+  return {
+    chatGuid: "",
+    pollMessageGuid: "",
+    action: 0,
+    at: undefined,
+    actor: undefined,
+    created: undefined,
+    optionAdded: undefined,
+    voted: undefined,
+    unvoted: undefined,
+  };
 }
 
 export const PollChangeEvent: MessageFns<PollChangeEvent> = {
@@ -1367,11 +1769,26 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
     if (message.pollMessageGuid !== "") {
       writer.uint32(18).string(message.pollMessageGuid);
     }
-    if (message.message !== undefined) {
-      Message.encode(message.message, writer.uint32(26).fork()).join();
-    }
     if (message.action !== 0) {
-      writer.uint32(32).int32(message.action);
+      writer.uint32(24).int32(message.action);
+    }
+    if (message.at !== undefined) {
+      Timestamp.encode(toTimestamp(message.at), writer.uint32(34).fork()).join();
+    }
+    if (message.actor !== undefined) {
+      PollActor.encode(message.actor, writer.uint32(42).fork()).join();
+    }
+    if (message.created !== undefined) {
+      PollCreated.encode(message.created, writer.uint32(82).fork()).join();
+    }
+    if (message.optionAdded !== undefined) {
+      PollOptionAdded.encode(message.optionAdded, writer.uint32(90).fork()).join();
+    }
+    if (message.voted !== undefined) {
+      PollVoted.encode(message.voted, writer.uint32(98).fork()).join();
+    }
+    if (message.unvoted !== undefined) {
+      PollUnvoted.encode(message.unvoted, writer.uint32(106).fork()).join();
     }
     return writer;
   },
@@ -1400,19 +1817,59 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
           continue;
         }
         case 3: {
-          if (tag !== 26) {
-            break;
-          }
-
-          message.message = Message.decode(reader, reader.uint32());
-          continue;
-        }
-        case 4: {
-          if (tag !== 32) {
+          if (tag !== 24) {
             break;
           }
 
           message.action = reader.int32() as any;
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.at = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.actor = PollActor.decode(reader, reader.uint32());
+          continue;
+        }
+        case 10: {
+          if (tag !== 82) {
+            break;
+          }
+
+          message.created = PollCreated.decode(reader, reader.uint32());
+          continue;
+        }
+        case 11: {
+          if (tag !== 90) {
+            break;
+          }
+
+          message.optionAdded = PollOptionAdded.decode(reader, reader.uint32());
+          continue;
+        }
+        case 12: {
+          if (tag !== 98) {
+            break;
+          }
+
+          message.voted = PollVoted.decode(reader, reader.uint32());
+          continue;
+        }
+        case 13: {
+          if (tag !== 106) {
+            break;
+          }
+
+          message.unvoted = PollUnvoted.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -1436,8 +1893,17 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
         : isSet(object.poll_message_guid)
         ? globalThis.String(object.poll_message_guid)
         : "",
-      message: isSet(object.message) ? Message.fromJSON(object.message) : undefined,
       action: isSet(object.action) ? pollActionFromJSON(object.action) : 0,
+      at: isSet(object.at) ? fromJsonTimestamp(object.at) : undefined,
+      actor: isSet(object.actor) ? PollActor.fromJSON(object.actor) : undefined,
+      created: isSet(object.created) ? PollCreated.fromJSON(object.created) : undefined,
+      optionAdded: isSet(object.optionAdded)
+        ? PollOptionAdded.fromJSON(object.optionAdded)
+        : isSet(object.option_added)
+        ? PollOptionAdded.fromJSON(object.option_added)
+        : undefined,
+      voted: isSet(object.voted) ? PollVoted.fromJSON(object.voted) : undefined,
+      unvoted: isSet(object.unvoted) ? PollUnvoted.fromJSON(object.unvoted) : undefined,
     };
   },
 
@@ -1449,11 +1915,26 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
     if (message.pollMessageGuid !== "") {
       obj.pollMessageGuid = message.pollMessageGuid;
     }
-    if (message.message !== undefined) {
-      obj.message = Message.toJSON(message.message);
-    }
     if (message.action !== 0) {
       obj.action = pollActionToJSON(message.action);
+    }
+    if (message.at !== undefined) {
+      obj.at = message.at.toISOString();
+    }
+    if (message.actor !== undefined) {
+      obj.actor = PollActor.toJSON(message.actor);
+    }
+    if (message.created !== undefined) {
+      obj.created = PollCreated.toJSON(message.created);
+    }
+    if (message.optionAdded !== undefined) {
+      obj.optionAdded = PollOptionAdded.toJSON(message.optionAdded);
+    }
+    if (message.voted !== undefined) {
+      obj.voted = PollVoted.toJSON(message.voted);
+    }
+    if (message.unvoted !== undefined) {
+      obj.unvoted = PollUnvoted.toJSON(message.unvoted);
     }
     return obj;
   },
@@ -1465,10 +1946,23 @@ export const PollChangeEvent: MessageFns<PollChangeEvent> = {
     const message = createBasePollChangeEvent();
     message.chatGuid = object.chatGuid ?? "";
     message.pollMessageGuid = object.pollMessageGuid ?? "";
-    message.message = (object.message !== undefined && object.message !== null)
-      ? Message.fromPartial(object.message)
-      : undefined;
     message.action = object.action ?? 0;
+    message.at = object.at ?? undefined;
+    message.actor = (object.actor !== undefined && object.actor !== null)
+      ? PollActor.fromPartial(object.actor)
+      : undefined;
+    message.created = (object.created !== undefined && object.created !== null)
+      ? PollCreated.fromPartial(object.created)
+      : undefined;
+    message.optionAdded = (object.optionAdded !== undefined && object.optionAdded !== null)
+      ? PollOptionAdded.fromPartial(object.optionAdded)
+      : undefined;
+    message.voted = (object.voted !== undefined && object.voted !== null)
+      ? PollVoted.fromPartial(object.voted)
+      : undefined;
+    message.unvoted = (object.unvoted !== undefined && object.unvoted !== null)
+      ? PollUnvoted.fromPartial(object.unvoted)
+      : undefined;
     return message;
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,5 +90,11 @@ export type {
   StickerPlacement,
   TextFormatInput,
 } from "./types/messages.js";
-export type { PollInfo, PollOption, PollVote } from "./types/polls.js";
+export type {
+  PollActor,
+  PollChangeDelta,
+  PollInfo,
+  PollOption,
+  PollVote,
+} from "./types/polls.js";
 export { Reaction } from "./types/reactions.js";

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -511,7 +511,10 @@ export class MessagesResource {
    * }
    * ```
    */
-  fetchMissed(cursor: string, options?: FetchMissedOptions): Paginated<Message> {
+  fetchMissed(
+    cursor: string,
+    options?: FetchMissedOptions
+  ): Paginated<Message> {
     return this.list({
       afterCursor: cursor,
       chatGuid: options?.chatGuid,

--- a/src/resources/polls.ts
+++ b/src/resources/polls.ts
@@ -6,15 +6,12 @@
  */
 
 import { fromGrpcError } from "../errors/error-handler.ts";
-import {
-  PollAction,
-  type PollChangeEvent,
-} from "../generated/photon/imessage/v1/poll_service.ts";
+import type { PollChangeEvent as ProtoPollChangeEvent } from "../generated/photon/imessage/v1/poll_service.ts";
 import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { PollServiceClient } from "../transport/grpc-client.ts";
-import { mapMessage, mapPollInfo } from "../transport/mapper.ts";
+import { mapPollChangeEvent, mapPollInfo } from "../transport/mapper.ts";
 import type { ChatGuid, MessageGuid } from "../types/branded.ts";
-import { chatGuid, messageGuid } from "../types/branded.ts";
+import { messageGuid } from "../types/branded.ts";
 import type { CommandReceipt } from "../types/common.ts";
 import type { PollEvent } from "../types/events.ts";
 import type { PollInfo } from "../types/polls.ts";
@@ -125,28 +122,38 @@ export class PollsResource {
   // Event subscription
   // -------------------------------------------------------------------------
 
-  /** Subscribe to poll change events. Returns a typed event stream. */
+  /**
+   * Subscribe to poll change events.
+   *
+   * Each event is self-contained: `delta` is a discriminated union that
+   * carries the full post-change poll state (`created`, `optionAdded`) or
+   * the voter's current selection (`voted`). `actor` identifies who
+   * triggered the change; `at` is the triggering message's timestamp.
+   *
+   * No `polls.get()` round-trip is required for typical UI rendering.
+   */
   subscribe(): TypedEventStream<PollEvent> {
     const rpcStream = this._client.subscribePollEvents({});
 
     async function* mapEvents(): AsyncGenerator<PollEvent> {
       try {
         for await (const proto of rpcStream) {
-          const timestamp = proto.timestamp ?? new Date();
-
           if (proto.pollChanged === undefined) {
             continue;
           }
 
-          const evt: PollChangeEvent = proto.pollChanged;
+          const evt: ProtoPollChangeEvent = proto.pollChanged;
+          const mapped = mapPollChangeEvent(evt);
 
           yield {
             type: "poll.changed" as const,
-            chatGuid: chatGuid(evt.chatGuid),
-            pollMessageGuid: messageGuid(evt.pollMessageGuid),
-            message: mapMessage(unwrap(evt.message, "message")),
-            action: mapPollAction(evt.action),
-            timestamp,
+            chatGuid: mapped.chatGuid,
+            pollMessageGuid: mapped.pollMessageGuid,
+            actor: mapped.actor,
+            at: mapped.at,
+            delta: mapped.delta,
+            action: mapped.delta.type,
+            timestamp: proto.timestamp ?? new Date(),
           };
         }
       } catch (err) {
@@ -155,29 +162,5 @@ export class PollsResource {
     }
 
     return new TypedEventStream<PollEvent>(mapEvents());
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Map a proto PollAction enum to the SDK PollEvent action literal.
- */
-function mapPollAction(
-  action: PollAction
-): "created" | "voted" | "unvoted" | "optionAdded" {
-  switch (action) {
-    case PollAction.POLL_ACTION_CREATED:
-      return "created";
-    case PollAction.POLL_ACTION_VOTED:
-      return "voted";
-    case PollAction.POLL_ACTION_UNVOTED:
-      return "unvoted";
-    case PollAction.POLL_ACTION_OPTION_ADDED:
-      return "optionAdded";
-    default:
-      return "created";
   }
 }

--- a/src/transport/mapper.ts
+++ b/src/transport/mapper.ts
@@ -28,6 +28,8 @@ import {
   TransferState as ProtoTransferState,
 } from "../generated/photon/imessage/v1/message_service.ts";
 import type {
+  PollActor as ProtoPollActor,
+  PollChangeEvent as ProtoPollChangeEvent,
   PollInfo as ProtoPollInfo,
   PollOption as ProtoPollOption,
   PollVote as ProtoPollVote,
@@ -40,7 +42,9 @@ import type { AddressInfo } from "../types/addresses.ts";
 import type { AttachmentInfo } from "../types/attachments.ts";
 import {
   attachmentGuid,
+  type ChatGuid,
   chatGuid,
+  type MessageGuid,
   messageGuid,
 } from "../types/branded.ts";
 import type { Chat } from "../types/chats.ts";
@@ -52,7 +56,14 @@ import type {
 } from "../types/enums.ts";
 import type { FindMyFriend } from "../types/locations.ts";
 import type { Message } from "../types/messages.ts";
-import type { PollInfo, PollOption, PollVote } from "../types/polls.ts";
+import type {
+  PollActor,
+  PollChangeDelta,
+  PollInfo,
+  PollOption,
+  PollVote,
+} from "../types/polls.ts";
+import { unwrap } from "../utils/unwrap.ts";
 
 // ---------------------------------------------------------------------------
 // Timestamp conversion
@@ -323,6 +334,77 @@ export function mapPollInfo(proto: ProtoPollInfo): PollInfo {
     title: proto.title,
     options: proto.options.map(mapPollOption),
     votes: proto.votes.map(mapPollVote),
+  };
+}
+
+/**
+ * Map a proto `PollActor` to the SDK `PollActor`.
+ *
+ * ts-proto uses `""` for missing string fields; we normalize to `undefined`
+ * so the SDK's `address?: string` contract is truthful.
+ */
+export function mapPollActor(proto: ProtoPollActor): PollActor {
+  return {
+    address: proto.address === "" ? undefined : proto.address,
+    isFromMe: proto.isFromMe,
+  };
+}
+
+/**
+ * Map a proto `PollChangeEvent`'s flattened oneof fields into a
+ * discriminated `PollChangeDelta`.
+ *
+ * ts-proto represents proto3 oneof as separate optional fields rather than a
+ * discriminated union, so we detect which one is set and rebuild the union
+ * here. Exactly one of `created` / `optionAdded` / `voted` / `unvoted` is
+ * expected to be set by the server.
+ */
+export function mapPollDelta(proto: ProtoPollChangeEvent): PollChangeDelta {
+  if (proto.created !== undefined) {
+    return {
+      type: "created",
+      title: proto.created.title,
+      options: proto.created.options.map(mapPollOption),
+    };
+  }
+  if (proto.optionAdded !== undefined) {
+    return {
+      type: "optionAdded",
+      title: proto.optionAdded.title,
+      options: proto.optionAdded.options.map(mapPollOption),
+    };
+  }
+  if (proto.voted !== undefined) {
+    return {
+      type: "voted",
+      optionIdentifiers: proto.voted.optionIdentifiers,
+    };
+  }
+  if (proto.unvoted !== undefined) {
+    return { type: "unvoted" };
+  }
+  throw new Error(
+    "PollChangeEvent delta oneof is empty — server did not populate a payload"
+  );
+}
+
+/**
+ * Map a proto `PollChangeEvent` into the SDK shape minus transport-level
+ * fields (the stream-level `timestamp` is applied by the resource).
+ */
+export function mapPollChangeEvent(proto: ProtoPollChangeEvent): {
+  chatGuid: ChatGuid;
+  pollMessageGuid: MessageGuid;
+  actor: PollActor;
+  at: Date;
+  delta: PollChangeDelta;
+} {
+  return {
+    chatGuid: chatGuid(proto.chatGuid),
+    pollMessageGuid: messageGuid(proto.pollMessageGuid),
+    actor: mapPollActor(unwrap(proto.actor, "actor")),
+    at: unwrap(proto.at, "at"),
+    delta: mapPollDelta(proto),
   };
 }
 

--- a/src/types/branded.ts
+++ b/src/types/branded.ts
@@ -47,4 +47,3 @@ export function messageGuid(raw: string): MessageGuid {
 export function attachmentGuid(raw: string): AttachmentGuid {
   return raw as AttachmentGuid;
 }
-

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -36,4 +36,3 @@ export type MessageItemType =
 
 /** The underlying transport service for a chat. */
 export type ChatServiceType = "iMessage" | "SMS";
-

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -11,6 +11,7 @@
 import type { ChatGuid, MessageGuid } from "./branded.ts";
 import type { FindMyFriend } from "./locations.ts";
 import type { Message } from "./messages.ts";
+import type { PollActor, PollChangeDelta } from "./polls.ts";
 
 // ---------------------------------------------------------------------------
 // MessageEvent
@@ -102,12 +103,36 @@ export interface GroupEvent {
 // PollEvent
 // ---------------------------------------------------------------------------
 
-/** An event indicating a poll was created or interacted with. */
+/**
+ * An event indicating a poll was created or interacted with.
+ *
+ * The event is self-contained — the `delta` discriminated union carries the
+ * full post-change data for `created` / `optionAdded`, or the voter's
+ * current full selection for `voted`. No `polls.get()` round-trip is
+ * required for common UI rendering.
+ *
+ * Switch on `delta.type` (or equivalently `action`) to narrow the payload.
+ */
 export interface PollEvent {
-  readonly action: "created" | "voted" | "unvoted" | "optionAdded";
+  /**
+   * Action discriminator — mirrors `delta.type`. Convenience alias for
+   * callers that only need to branch on the action kind.
+   */
+  readonly action: PollChangeDelta["type"];
+  /** Who made the change. */
+  readonly actor: PollActor;
+  /**
+   * When the change was written (the triggering message's dateCreated).
+   * May differ slightly from the event's delivery time.
+   */
+  readonly at: Date;
+  /** Chat the poll belongs to. */
   readonly chatGuid: ChatGuid;
-  readonly message: Message;
+  /** The action and its per-action payload. */
+  readonly delta: PollChangeDelta;
+  /** GUID of the root poll message (stable across the poll's lifetime). */
   readonly pollMessageGuid: MessageGuid;
+  /** The delivery timestamp assigned by the server stream. */
   readonly timestamp: Date;
   readonly type: "poll.changed";
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -8,10 +8,10 @@
  * to the concrete event shape, enabling type-safe `subscribe()` overloads.
  */
 
-import type { ChatGuid, MessageGuid } from "./branded.ts";
-import type { FindMyFriend } from "./locations.ts";
-import type { Message } from "./messages.ts";
-import type { PollActor, PollChangeDelta } from "./polls.ts";
+import type { ChatGuid, MessageGuid } from "./branded.js";
+import type { FindMyFriend } from "./locations.js";
+import type { Message } from "./messages.js";
+import type { PollActor, PollChangeDelta } from "./polls.js";
 
 // ---------------------------------------------------------------------------
 // MessageEvent

--- a/src/types/polls.ts
+++ b/src/types/polls.ts
@@ -1,8 +1,8 @@
 /**
  * Poll-related domain types.
  *
- * Wraps the proto `PollInfo`, `PollOption`, and `PollVote` with branded
- * identifiers.
+ * Mirrors the gRPC `poll_service.proto` types with branded identifiers and
+ * a discriminated union for the per-action event payload.
  */
 
 import type { ChatGuid, MessageGuid } from "./branded.js";
@@ -50,3 +50,56 @@ export interface PollInfo {
   /** Votes that have been cast so far. */
   readonly votes: readonly PollVote[];
 }
+
+// ---------------------------------------------------------------------------
+// PollActor
+// ---------------------------------------------------------------------------
+
+/**
+ * Who triggered a poll change.
+ *
+ * For self-initiated changes — including those written from another of the
+ * user's devices — `isFromMe` is `true` and `address` is typically
+ * `undefined` (chat.db does not store a handle row for the local account).
+ */
+export interface PollActor {
+  /**
+   * Handle address (e.g. `"user@example.com"`, `"+14155550123"`), if the
+   * underlying chat.db row carries a resolvable handle.
+   */
+  readonly address?: string;
+  /** True when the change was written by the local iMessage account. */
+  readonly isFromMe: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// PollChangeDelta
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-action payload for a poll change. Discriminated by `type`.
+ *
+ * - `created` / `optionAdded` ship the complete post-change poll state —
+ *   the UI can render without an extra `polls.get()` round-trip.
+ * - `voted` ships the actor's current full selection (iMessage's vote
+ *   protocol represents votes as the voter's picks, not deltas).
+ * - `unvoted` has no extra fields (iMessage has no per-option unvote).
+ */
+export type PollChangeDelta =
+  | {
+      readonly type: "created";
+      readonly title: string;
+      readonly options: readonly PollOption[];
+    }
+  | {
+      readonly type: "optionAdded";
+      readonly title: string;
+      readonly options: readonly PollOption[];
+    }
+  | {
+      readonly type: "voted";
+      readonly optionIdentifiers: readonly string[];
+    }
+  | {
+      readonly type: "unvoted";
+    };


### PR DESCRIPTION
### Summary
Adopt the new `PollChangeEvent` wire shape from the server: events now carry `actor` (who), `at` (when), and a typed `delta` (what changed), instead of an embedded `Message`. `delta` is a discriminated union that ships the full post-change state so UIs can render without a follow-up `polls.get()` call for common cases.

### Why
The server now derives poll events from `chat.db` rather than from RPC success callbacks. That gives consumers three things the old shape could not express:

1. **Peer attribution** — `actor.isFromMe = false` and a resolved `actor.address` for changes written by the other party or by another of the user's devices.
2. **Real timestamps** — `at` is the triggering row's `dateCreated`, not the time the RPC returned.
3. **Self-contained payloads** — `delta` carries the new title + options on `created / optionAdded`, and the voter's current full selection on `voted`.

### What changed
| File | Change |
|---|---|
| `proto/photon/imessage/v1/poll_service.proto` | Mirror server proto: new `PollActor / PollCreated / PollOptionAdded / PollVoted / PollUnvoted`; `PollChangeEvent` gains `at`, `actor`, and a `delta` oneof. |
| `src/generated/photon/imessage/v1/poll_service.ts` | Regenerated. |
| `src/types/polls.ts` | Add `PollActor` and `PollChangeDelta` discriminated union. |
| `src/types/events.ts` | `PollEvent` replaces `message` with `actor / at / delta`. `action` retained as a convenience alias for `delta.type`. |
| `src/transport/mapper.ts` | Add `mapPollActor / mapPollDelta / mapPollChangeEvent`. Collapse ts-proto's flattened oneof back into a discriminated union. Normalize empty-string `address` to `undefined`. |
| `src/resources/polls.ts` | `PollsResource.subscribe` delegates to `mapPollChangeEvent`; the inline `mapPollAction` helper is gone. |
| `src/index.ts` | Export `PollActor` and `PollChangeDelta`. |

### Usage after this change

```ts
for await (const event of im.polls.subscribe()) {
  // actor attribution — works for self, peer, and multi-device writes
  if (!event.actor.isFromMe) {
    console.log(`peer ${event.actor.address} changed poll at ${event.at.toISOString()}`);
  }

  // discriminated delta — no polls.get() needed for common rendering
  switch (event.delta.type) {
    case "created":
    case "optionAdded":
      renderOptions(event.delta.title, event.delta.options);
      break;
    case "voted":
      renderSelection(event.actor, event.delta.optionIdentifiers);
      break;
    case "unvoted":
      clearSelection(event.actor);
      break;
  }
}
```

### Breaking changes
`PollEvent.message` is removed. Consumers that used `event.message.dateCreated` or `event.message.isFromMe` should read `event.at` and `event.actor.isFromMe` respectively; consumers that used `event.message.guid` (the triggering row) have no direct replacement — use `event.pollMessageGuid` for the poll root, or call `polls.get` if the exact triggering row is needed.

### Compatibility
Requires the server from the matching `refactor/poll-change-event-from-chatdb` release. Older servers will either fail to populate the `delta` oneof (the mapper throws `"PollChangeEvent delta oneof is empty"` at the transport boundary, which surfaces as a stream error) or send the old shape on the removed field numbers (which ts-proto silently ignores).

### Test plan
- [ ] `bun x tsc --noEmit`
- [ ] `bun run lint` (biome check)
- [ ] E2E against a locally-built server on the matching branch: create, vote, vote-switch, unvote, addOption, vote on new option; each yields exactly one stream event with the right `delta.type` and `actor.isFromMe = true`.
- [ ] E2E with a peer sender: event arrives with `actor.isFromMe = false` and a resolved `actor.address`.
- [ ] Verify `polls.get()` after the flow returns the expected aggregated `PollInfo` (title + options + votes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Poll change events now include actor info (who triggered the change) and precise timestamps.
  * Events no longer embed the full message; they carry an action-specific delta payload — inspect delta.type to handle created, optionAdded, voted, or unvoted cases.
  * Public types updated to expose PollActor and a discriminated PollChangeDelta for per-action payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->