### PR TITLE
feat(messages): expose addUploadedAttachment for multipart send

### DIFF
--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -166,7 +166,11 @@ message StickerPlacement {
 
 message MessagePart {
   optional string text = 1;
-  optional string attachment_path = 2;
+  // attachment_path is server-internal; SDK clients use attachment_guid.
+  oneof attachment {
+    string attachment_path = 2;
+    string attachment_guid = 8;
+  }
   optional string attachment_name = 3;
   reserved 4;
   optional string mention = 5;

--- a/src/builders/message-builder.ts
+++ b/src/builders/message-builder.ts
@@ -9,7 +9,7 @@
  * This builder powers Tier 3.
  */
 
-import type { MessageGuid } from "../types/branded.js";
+import type { AttachmentGuid, MessageGuid } from "../types/branded.js";
 import type { MessageEffect, TextEffect } from "../types/effects.js";
 import type {
   ComposedMessage,
@@ -86,7 +86,7 @@ export class MessageBuilder {
    * @param guid - GUID returned by a prior `attachments.upload()` call.
    * @param options - Optional display name for the file.
    */
-  addUploadedAttachment(guid: string, options?: { name?: string }): this {
+  addUploadedAttachment(guid: AttachmentGuid, options?: { name?: string }): this {
     this._parts.push({
       attachmentGuid: guid,
       attachmentName: options?.name,

--- a/src/builders/message-builder.ts
+++ b/src/builders/message-builder.ts
@@ -81,14 +81,14 @@ export class MessageBuilder {
   }
 
   /**
-   * Append an attachment part.
+   * Append an attachment part by GUID returned from `attachments.upload()`.
    *
-   * @param path - Server-side file path for the attachment.
+   * @param guid - GUID returned by a prior `attachments.upload()` call.
    * @param options - Optional display name for the file.
    */
-  addAttachment(path: string, options?: { name?: string }): this {
+  addUploadedAttachment(guid: string, options?: { name?: string }): this {
     this._parts.push({
-      attachmentPath: path,
+      attachmentGuid: guid,
       attachmentName: options?.name,
       partIndex: this._parts.length,
     });
@@ -202,7 +202,7 @@ export class MessageBuilder {
     if (this._parts.length === 0) {
       throw new Error(
         "MessageBuilder: cannot build an empty message. " +
-          "Add at least one part with addText(), addMention(), or addAttachment()."
+          "Add at least one part with addText(), addMention(), or addUploadedAttachment()."
       );
     }
 

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -248,6 +248,7 @@ export interface StickerPlacement {
 export interface MessagePart {
   text?: string | undefined;
   attachmentPath?: string | undefined;
+  attachmentGuid?: string | undefined;
   attachmentName?: string | undefined;
   mention?: string | undefined;
   partIndex?: number | undefined;
@@ -2204,6 +2205,7 @@ function createBaseMessagePart(): MessagePart {
   return {
     text: undefined,
     attachmentPath: undefined,
+    attachmentGuid: undefined,
     attachmentName: undefined,
     mention: undefined,
     partIndex: undefined,
@@ -2218,6 +2220,9 @@ export const MessagePart: MessageFns<MessagePart> = {
     }
     if (message.attachmentPath !== undefined) {
       writer.uint32(18).string(message.attachmentPath);
+    }
+    if (message.attachmentGuid !== undefined) {
+      writer.uint32(66).string(message.attachmentGuid);
     }
     if (message.attachmentName !== undefined) {
       writer.uint32(26).string(message.attachmentName);
@@ -2255,6 +2260,14 @@ export const MessagePart: MessageFns<MessagePart> = {
           }
 
           message.attachmentPath = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.attachmentGuid = reader.string();
           continue;
         }
         case 3: {
@@ -2306,6 +2319,11 @@ export const MessagePart: MessageFns<MessagePart> = {
         : isSet(object.attachment_path)
         ? globalThis.String(object.attachment_path)
         : undefined,
+      attachmentGuid: isSet(object.attachmentGuid)
+        ? globalThis.String(object.attachmentGuid)
+        : isSet(object.attachment_guid)
+        ? globalThis.String(object.attachment_guid)
+        : undefined,
       attachmentName: isSet(object.attachmentName)
         ? globalThis.String(object.attachmentName)
         : isSet(object.attachment_name)
@@ -2331,6 +2349,9 @@ export const MessagePart: MessageFns<MessagePart> = {
     if (message.attachmentPath !== undefined) {
       obj.attachmentPath = message.attachmentPath;
     }
+    if (message.attachmentGuid !== undefined) {
+      obj.attachmentGuid = message.attachmentGuid;
+    }
     if (message.attachmentName !== undefined) {
       obj.attachmentName = message.attachmentName;
     }
@@ -2353,6 +2374,7 @@ export const MessagePart: MessageFns<MessagePart> = {
     const message = createBaseMessagePart();
     message.text = object.text ?? undefined;
     message.attachmentPath = object.attachmentPath ?? undefined;
+    message.attachmentGuid = object.attachmentGuid ?? undefined;
     message.attachmentName = object.attachmentName ?? undefined;
     message.mention = object.mention ?? undefined;
     message.partIndex = object.partIndex ?? undefined;

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -73,7 +73,7 @@ function toProtoMessageParts(
 ): ProtoMessagePart[] {
   return parts.map((p) => ({
     text: p.text,
-    attachmentPath: p.attachmentPath,
+    attachmentGuid: p.attachmentGuid,
     attachmentName: p.attachmentName,
     mention: p.mention,
     partIndex: p.partIndex,

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -199,7 +199,7 @@ export interface SendOptions {
 /** A single part within a multi-part composed message. */
 export interface MessagePart {
   /** GUID returned by `attachments.upload()`. */
-  readonly attachmentGuid?: string;
+  readonly attachmentGuid?: AttachmentGuid;
   /** Display name for the attachment file. */
   readonly attachmentName?: string;
   /** Formatting instructions for the text in this part. */

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -198,10 +198,10 @@ export interface SendOptions {
 
 /** A single part within a multi-part composed message. */
 export interface MessagePart {
+  /** GUID returned by `attachments.upload()`. */
+  readonly attachmentGuid?: string;
   /** Display name for the attachment file. */
   readonly attachmentName?: string;
-  /** Server-side file path for an attachment. */
-  readonly attachmentPath?: string;
   /** Formatting instructions for the text in this part. */
   readonly formatting?: readonly TextFormatInput[];
   /** Address to mention (e.g. "john@icloud.com"). */

--- a/tests/unit/messages-resource.test.ts
+++ b/tests/unit/messages-resource.test.ts
@@ -56,8 +56,8 @@ describe("MessagesResource sticker placement", () => {
 
     await resource.sendMultipart(chatGuidValue, [
       { text: "look at these" },
-      { attachmentGuid: "att-a", attachmentName: "a.jpg" },
-      { attachmentGuid: "att-b", attachmentName: "b.jpg" },
+      { attachmentGuid: "att-a" as AttachmentGuid, attachmentName: "a.jpg" },
+      { attachmentGuid: "att-b" as AttachmentGuid, attachmentName: "b.jpg" },
     ]);
 
     const parts = (capturedRequest?.parts as Array<Record<string, unknown>>);

--- a/tests/unit/messages-resource.test.ts
+++ b/tests/unit/messages-resource.test.ts
@@ -45,6 +45,28 @@ describe("MessagesResource sticker placement", () => {
     });
   });
 
+  it("forwards attachmentGuid on each multipart part", async () => {
+    let capturedRequest: Record<string, unknown> | undefined;
+    const resource = new MessagesResource({
+      async send(request: Record<string, unknown>) {
+        capturedRequest = request;
+        return { receipt: { guid: "sent-multi" } };
+      },
+    } as any);
+
+    await resource.sendMultipart(chatGuidValue, [
+      { text: "look at these" },
+      { attachmentGuid: "att-a", attachmentName: "a.jpg" },
+      { attachmentGuid: "att-b", attachmentName: "b.jpg" },
+    ]);
+
+    const parts = (capturedRequest?.parts as Array<Record<string, unknown>>);
+    expect(parts).toHaveLength(3);
+    expect(parts[0]?.attachmentGuid).toBeUndefined();
+    expect(parts[1]?.attachmentGuid).toBe("att-a");
+    expect(parts[2]?.attachmentGuid).toBe("att-b");
+  });
+
   it("does not forward a removed send service override", async () => {
     let capturedRequest: Record<string, unknown> | undefined;
     const resource = new MessagesResource({


### PR DESCRIPTION
## Summary

Replaces the inert `attachmentPath` field on `MessagePart` with an
`attachmentGuid` field populated by `attachments.upload()`. This is the
SDK side of the multi-attachment multipart rollout — paired with the
server's `oneof attachment` migration.

## Public API change

```ts
// Before
builder.addAttachment("/server/path.jpg", { name: "x.jpg" });

// After
const { guid } = await im.attachments.upload({ fileName, mimeType, data });
builder.addUploadedAttachment(guid, { name: "x.jpg" });
```

`MessagePart.attachmentPath` is removed from `src/types/messages.ts`. The
former value was never usable by external clients (the SDK has no access
to the server's filesystem), so this is the API made honest rather than
a feature regression.

## Wire change

`proto/photon/imessage/v1/message_service.proto` now declares:

```proto
oneof attachment {
  string attachment_path = 2;
  string attachment_guid = 8;
}
```

Generated code (`src/generated/.../message_service.ts`) adds the
`attachmentGuid` field with ser/de at tag 8. Tag 2 is preserved for wire
compatibility with older payloads.

## Tests

`tests/unit/messages-resource.test.ts` adds a case asserting that
`attachmentGuid` is forwarded on each part of a multipart send (mixed
`text + guid + guid`).

## Test plan

- [x] `bun test`
- [x] `bun x ultracite check`
- [x] End-to-end against a local server: upload two PNG buffers, compose
      with two `addUploadedAttachment` calls, send to a real chat,
      confirm both attachments appear in `chat.db`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Message composition API updated: attachment identifiers now use GUIDs instead of file paths — update any code that supplies attachments.
* **New Features**
  * Attachments can be represented either as server-side paths or as SDK GUIDs.
* **Tests**
  * Added test coverage for multipart message sends with mixed text and attachment parts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->