### PR TITLE
fix: expose poll unvote option identifiers

### DIFF
--- a/proto/photon/imessage/v1/poll_types.proto
+++ b/proto/photon/imessage/v1/poll_types.proto
@@ -26,7 +26,7 @@ message PollOption {
 }
 
 
-// One participant's current vote. Exactly one option per participant.
+// One selected option in a participant's current vote snapshot.
 message PollParticipantVote {
 
   SingleServiceAddressInfo participant = 1;
@@ -88,9 +88,13 @@ message PollVoted {
 }
 
 
-// A participant cleared their current vote. The participant is carried by the
+// A participant deselected one option. The participant is carried by the
 // enclosing event actor.
-message PollUnvoted {}
+message PollUnvoted {
+
+  string option_identifier = 1;
+
+}
 
 
 // ---------------------------------------------------------------------------

--- a/src/generated/photon/imessage/v1/poll_types.ts
+++ b/src/generated/photon/imessage/v1/poll_types.ts
@@ -22,7 +22,7 @@ export interface PollOption {
   creatorHandle?: string | undefined;
 }
 
-/** One participant's current vote. Exactly one option per participant. */
+/** One selected option in a participant's current vote snapshot. */
 export interface PollParticipantVote {
   participant: SingleServiceAddressInfo | undefined;
   optionIdentifier: string;
@@ -65,10 +65,11 @@ export interface PollVoted {
 }
 
 /**
- * A participant cleared their current vote. The participant is carried by the
+ * A participant deselected one option. The participant is carried by the
  * enclosing event actor.
  */
 export interface PollUnvoted {
+  optionIdentifier: string;
 }
 
 /** A discrete state transition observed for a poll. */
@@ -617,11 +618,14 @@ export const PollVoted: MessageFns<PollVoted> = {
 };
 
 function createBasePollUnvoted(): PollUnvoted {
-  return {};
+  return { optionIdentifier: "" };
 }
 
 export const PollUnvoted: MessageFns<PollUnvoted> = {
-  encode(_: PollUnvoted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+  encode(message: PollUnvoted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.optionIdentifier !== "") {
+      writer.uint32(10).string(message.optionIdentifier);
+    }
     return writer;
   },
 
@@ -632,6 +636,14 @@ export const PollUnvoted: MessageFns<PollUnvoted> = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.optionIdentifier = reader.string();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -641,20 +653,30 @@ export const PollUnvoted: MessageFns<PollUnvoted> = {
     return message;
   },
 
-  fromJSON(_: any): PollUnvoted {
-    return {};
+  fromJSON(object: any): PollUnvoted {
+    return {
+      optionIdentifier: isSet(object.optionIdentifier)
+        ? globalThis.String(object.optionIdentifier)
+        : isSet(object.option_identifier)
+        ? globalThis.String(object.option_identifier)
+        : "",
+    };
   },
 
-  toJSON(_: PollUnvoted): unknown {
+  toJSON(message: PollUnvoted): unknown {
     const obj: any = {};
+    if (message.optionIdentifier !== "") {
+      obj.optionIdentifier = message.optionIdentifier;
+    }
     return obj;
   },
 
   create(base?: DeepPartial<PollUnvoted>): PollUnvoted {
     return PollUnvoted.fromPartial(base ?? {});
   },
-  fromPartial(_: DeepPartial<PollUnvoted>): PollUnvoted {
+  fromPartial(object: DeepPartial<PollUnvoted>): PollUnvoted {
     const message = createBasePollUnvoted();
+    message.optionIdentifier = object.optionIdentifier ?? "";
     return message;
   },
 };

--- a/src/resources/polls.ts
+++ b/src/resources/polls.ts
@@ -139,7 +139,7 @@ export class PollsResource {
 
   /**
    * Subscribe to poll lifecycle events (created / option added / voted /
-   * unvoted).
+   * unvoted). Vote and unvote events include the affected option identifier.
    *
    * Pass `filter.pollMessage` to scope the stream to a single poll.
    */

--- a/src/transport/mapper.ts
+++ b/src/transport/mapper.ts
@@ -442,6 +442,7 @@ export function mapPollDelta(
   if (proto.unvoted) {
     return {
       type: "unvoted",
+      optionIdentifier: proto.unvoted.optionIdentifier,
     };
   }
   return undefined;

--- a/src/types/polls.ts
+++ b/src/types/polls.ts
@@ -40,4 +40,5 @@ export type PollChangeDelta =
     }
   | {
       readonly type: "unvoted";
+      readonly optionIdentifier: string;
     };


### PR DESCRIPTION
## Summary
- Add `option_identifier` to the `PollUnvoted` proto and regenerate the SDK poll types.
- Surface `delta.optionIdentifier` on `unvoted` poll events so vote and unvote deltas carry the affected option consistently.
- Update poll event type definitions and subscription docs for the option-level unvote event shape.

## Validation
- bun run generate
- bun run lint
- bun run check
- bun test
- bun run build
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Poll unvote tracking** - Unvote events in polls now include the specific option identifier that was deselected. Previously, when users removed votes from poll options, the system could not determine which option was affected. This fix enables proper poll change tracking and accurate event handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/advanced-imessage-ts/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->