### PR TITLE
feat: add location sharing requests

### DIFF
--- a/proto/photon/imessage/v1/location_service.proto
+++ b/proto/photon/imessage/v1/location_service.proto
@@ -23,6 +23,9 @@ service LocationService {
   rpc GetSharedFriendLocation(GetSharedFriendLocationRequest)
       returns (GetSharedFriendLocationResponse);
 
+  rpc RequestLocationSharing(RequestLocationSharingRequest)
+      returns (RequestLocationSharingResponse);
+
   rpc WatchSharedFriendLocations(WatchSharedFriendLocationsRequest)
       returns (stream WatchSharedFriendLocationsResponse);
 
@@ -58,6 +61,41 @@ message GetSharedFriendLocationRequest {
 message GetSharedFriendLocationResponse {
 
   SharedFriendLocation location = 1;
+
+}
+
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+// Sends a visible Find My location-sharing request card in `chat_guid`.
+//
+// Errors:
+//   INVALID_ARGUMENT  malformed address or chat_guid
+//   NOT_FOUND         chat is not visible to the current account
+message RequestLocationSharingRequest {
+
+  string chat_guid = 1;
+
+  string address = 2;
+
+  optional string client_message_id = 100;
+
+}
+
+
+message RequestLocationSharingResponse {
+
+  string address = 1;
+
+  bool requested = 2;
+
+  string request_status = 3;
+
+  optional string reason = 4;
+
+  optional string message_guid = 5;
 
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,6 +31,7 @@ import type {
   PollEvent,
 } from "./types/events.js";
 import type {
+  LocationRequestReceipt,
   SharedFriendLocation,
   SharedFriendLocationUpdated,
 } from "./types/locations.js";
@@ -184,11 +185,17 @@ export interface GroupsResource {
  *
  * - `list()` returns every friend currently sharing a location.
  * - `get(address)` fetches the latest snapshot for one friend.
+ * - `request(chat, address)` sends a visible Find My request card.
  * - `watch(address?)` streams location updates outside the durable event log.
  */
 export interface LocationsResource {
   get(address: string): Promise<SharedFriendLocation>;
   list(): Promise<SharedFriendLocation[]>;
+  request(
+    chat: string,
+    address: string,
+    options?: IdempotencyOptions
+  ): Promise<LocationRequestReceipt>;
   watch(address?: string): TypedEventStream<SharedFriendLocationUpdated>;
 }
 

--- a/src/generated/photon/imessage/v1/location_service.ts
+++ b/src/generated/photon/imessage/v1/location_service.ts
@@ -35,6 +35,27 @@ export interface GetSharedFriendLocationResponse {
 }
 
 /**
+ * Sends a visible Find My location-sharing request card in `chat_guid`.
+ *
+ * Errors:
+ *   INVALID_ARGUMENT  malformed address or chat_guid
+ *   NOT_FOUND         chat is not visible to the current account
+ */
+export interface RequestLocationSharingRequest {
+  chatGuid: string;
+  address: string;
+  clientMessageId?: string | undefined;
+}
+
+export interface RequestLocationSharingResponse {
+  address: string;
+  requested: boolean;
+  requestStatus: string;
+  reason?: string | undefined;
+  messageGuid?: string | undefined;
+}
+
+/**
  * Absent `address` = watch every shared location update. Present
  * `address` = watch updates for one address only.
  */
@@ -270,6 +291,238 @@ export const GetSharedFriendLocationResponse: MessageFns<GetSharedFriendLocation
   },
 };
 
+function createBaseRequestLocationSharingRequest(): RequestLocationSharingRequest {
+  return { chatGuid: "", address: "", clientMessageId: undefined };
+}
+
+export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingRequest> = {
+  encode(message: RequestLocationSharingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chatGuid !== "") {
+      writer.uint32(10).string(message.chatGuid);
+    }
+    if (message.address !== "") {
+      writer.uint32(18).string(message.address);
+    }
+    if (message.clientMessageId !== undefined) {
+      writer.uint32(802).string(message.clientMessageId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RequestLocationSharingRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRequestLocationSharingRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chatGuid = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.address = reader.string();
+          continue;
+        }
+        case 100: {
+          if (tag !== 802) {
+            break;
+          }
+
+          message.clientMessageId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RequestLocationSharingRequest {
+    return {
+      chatGuid: isSet(object.chatGuid)
+        ? globalThis.String(object.chatGuid)
+        : isSet(object.chat_guid)
+        ? globalThis.String(object.chat_guid)
+        : "",
+      address: isSet(object.address) ? globalThis.String(object.address) : "",
+      clientMessageId: isSet(object.clientMessageId)
+        ? globalThis.String(object.clientMessageId)
+        : isSet(object.client_message_id)
+        ? globalThis.String(object.client_message_id)
+        : undefined,
+    };
+  },
+
+  toJSON(message: RequestLocationSharingRequest): unknown {
+    const obj: any = {};
+    if (message.chatGuid !== "") {
+      obj.chatGuid = message.chatGuid;
+    }
+    if (message.address !== "") {
+      obj.address = message.address;
+    }
+    if (message.clientMessageId !== undefined) {
+      obj.clientMessageId = message.clientMessageId;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<RequestLocationSharingRequest>): RequestLocationSharingRequest {
+    return RequestLocationSharingRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<RequestLocationSharingRequest>): RequestLocationSharingRequest {
+    const message = createBaseRequestLocationSharingRequest();
+    message.chatGuid = object.chatGuid ?? "";
+    message.address = object.address ?? "";
+    message.clientMessageId = object.clientMessageId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseRequestLocationSharingResponse(): RequestLocationSharingResponse {
+  return { address: "", requested: false, requestStatus: "", reason: undefined, messageGuid: undefined };
+}
+
+export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingResponse> = {
+  encode(message: RequestLocationSharingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.address !== "") {
+      writer.uint32(10).string(message.address);
+    }
+    if (message.requested !== false) {
+      writer.uint32(16).bool(message.requested);
+    }
+    if (message.requestStatus !== "") {
+      writer.uint32(26).string(message.requestStatus);
+    }
+    if (message.reason !== undefined) {
+      writer.uint32(34).string(message.reason);
+    }
+    if (message.messageGuid !== undefined) {
+      writer.uint32(42).string(message.messageGuid);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): RequestLocationSharingResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseRequestLocationSharingResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.address = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.requested = reader.bool();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.requestStatus = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.reason = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.messageGuid = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RequestLocationSharingResponse {
+    return {
+      address: isSet(object.address) ? globalThis.String(object.address) : "",
+      requested: isSet(object.requested) ? globalThis.Boolean(object.requested) : false,
+      requestStatus: isSet(object.requestStatus)
+        ? globalThis.String(object.requestStatus)
+        : isSet(object.request_status)
+        ? globalThis.String(object.request_status)
+        : "",
+      reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
+      messageGuid: isSet(object.messageGuid)
+        ? globalThis.String(object.messageGuid)
+        : isSet(object.message_guid)
+        ? globalThis.String(object.message_guid)
+        : undefined,
+    };
+  },
+
+  toJSON(message: RequestLocationSharingResponse): unknown {
+    const obj: any = {};
+    if (message.address !== "") {
+      obj.address = message.address;
+    }
+    if (message.requested !== false) {
+      obj.requested = message.requested;
+    }
+    if (message.requestStatus !== "") {
+      obj.requestStatus = message.requestStatus;
+    }
+    if (message.reason !== undefined) {
+      obj.reason = message.reason;
+    }
+    if (message.messageGuid !== undefined) {
+      obj.messageGuid = message.messageGuid;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<RequestLocationSharingResponse>): RequestLocationSharingResponse {
+    return RequestLocationSharingResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<RequestLocationSharingResponse>): RequestLocationSharingResponse {
+    const message = createBaseRequestLocationSharingResponse();
+    message.address = object.address ?? "";
+    message.requested = object.requested ?? false;
+    message.requestStatus = object.requestStatus ?? "";
+    message.reason = object.reason ?? undefined;
+    message.messageGuid = object.messageGuid ?? undefined;
+    return message;
+  },
+};
+
 function createBaseWatchSharedFriendLocationsRequest(): WatchSharedFriendLocationsRequest {
   return { address: undefined };
 }
@@ -438,6 +691,14 @@ export const LocationServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    requestLocationSharing: {
+      name: "RequestLocationSharing",
+      requestType: RequestLocationSharingRequest as typeof RequestLocationSharingRequest,
+      requestStream: false,
+      responseType: RequestLocationSharingResponse as typeof RequestLocationSharingResponse,
+      responseStream: false,
+      options: {},
+    },
     watchSharedFriendLocations: {
       name: "WatchSharedFriendLocations",
       requestType: WatchSharedFriendLocationsRequest as typeof WatchSharedFriendLocationsRequest,
@@ -458,6 +719,10 @@ export interface LocationServiceImplementation<CallContextExt = {}> {
     request: GetSharedFriendLocationRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<GetSharedFriendLocationResponse>>;
+  requestLocationSharing(
+    request: RequestLocationSharingRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<RequestLocationSharingResponse>>;
   watchSharedFriendLocations(
     request: WatchSharedFriendLocationsRequest,
     context: CallContext & CallContextExt,
@@ -473,6 +738,10 @@ export interface LocationServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<GetSharedFriendLocationRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<GetSharedFriendLocationResponse>;
+  requestLocationSharing(
+    request: DeepPartial<RequestLocationSharingRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<RequestLocationSharingResponse>;
   watchSharedFriendLocations(
     request: DeepPartial<WatchSharedFriendLocationsRequest>,
     options?: CallOptions & CallOptionsExt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export type {
   PollEvent,
 } from "./types/events.js";
 export type {
+  LocationRequestReceipt,
   SharedFriendLocation,
   SharedFriendLocationUpdated,
 } from "./types/locations.js";

--- a/src/resources/locations.ts
+++ b/src/resources/locations.ts
@@ -2,10 +2,14 @@ import { fromGrpcError } from "../errors/error-handler.ts";
 import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { LocationServiceClient } from "../transport/grpc-client.ts";
 import {
+  mapLocationRequestReceipt,
   mapSharedFriendLocation,
   mapSharedFriendLocationUpdated,
 } from "../transport/mapper.ts";
+import { normalizeChatGuid } from "../types/chat-guid.ts";
+import type { IdempotencyOptions } from "../types/common.ts";
 import type {
+  LocationRequestReceipt,
   SharedFriendLocation,
   SharedFriendLocationUpdated,
 } from "../types/locations.ts";
@@ -17,6 +21,7 @@ import { unwrap } from "../utils/unwrap.ts";
  * - `list()` returns every friend currently sharing a location with this
  *   account.
  * - `get(address)` fetches the latest shared-location snapshot for one friend.
+ * - `request(chat, address)` sends a visible Find My request card in a chat.
  * - `watch(address?)` streams shared-location updates for all friends, or only
  *   one address when provided.
  */
@@ -51,6 +56,30 @@ export class LocationsResource {
     try {
       const response = await this._client.getSharedFriendLocation({ address });
       return mapSharedFriendLocation(unwrap(response.location, "location"));
+    } catch (err) {
+      throw fromGrpcError(err);
+    }
+  }
+
+  /**
+   * Request location sharing from one participant in a chat.
+   *
+   * This sends a visible Find My request card. It does not grant access by
+   * itself; the other person must accept or start sharing before `get`, `list`,
+   * or `watch` can return their location.
+   */
+  async request(
+    chat: string,
+    address: string,
+    options: IdempotencyOptions = {}
+  ): Promise<LocationRequestReceipt> {
+    try {
+      const response = await this._client.requestLocationSharing({
+        address,
+        chatGuid: normalizeChatGuid(chat),
+        clientMessageId: options.clientMessageId,
+      });
+      return mapLocationRequestReceipt(response);
     } catch (err) {
       throw fromGrpcError(err);
     }

--- a/src/transport/mapper.ts
+++ b/src/transport/mapper.ts
@@ -14,6 +14,7 @@ import type {
   ChatChangeEvent as ProtoChatChangeEvent,
 } from "../generated/photon/imessage/v1/chat_types.ts";
 import type { GroupChangeEvent as ProtoGroupChangeEvent } from "../generated/photon/imessage/v1/group_types.ts";
+import type { RequestLocationSharingResponse as ProtoRequestLocationSharingResponse } from "../generated/photon/imessage/v1/location_service.ts";
 import {
   FriendLocationType as ProtoFriendLocationType,
   type SharedFriendLocation as ProtoSharedFriendLocation,
@@ -69,6 +70,7 @@ import type {
   PollEvent,
 } from "../types/events.ts";
 import type {
+  LocationRequestReceipt,
   SharedFriendLocation,
   SharedFriendLocationUpdated,
 } from "../types/locations.ts";
@@ -472,6 +474,18 @@ export function mapSharedFriendLocationUpdated(
   return {
     location: mapSharedFriendLocation(unwrap(proto.location, "location")),
     sourceSequence: proto.sourceSequence,
+  };
+}
+
+export function mapLocationRequestReceipt(
+  proto: ProtoRequestLocationSharingResponse
+): LocationRequestReceipt {
+  return {
+    address: proto.address,
+    messageGuid: proto.messageGuid,
+    reason: proto.reason,
+    requested: proto.requested,
+    requestStatus: proto.requestStatus,
   };
 }
 

--- a/src/transport/metadata.ts
+++ b/src/transport/metadata.ts
@@ -63,6 +63,7 @@ const MUTATING_METHODS: ReadonlySet<string> = new Set([
   "/photon.imessage.v1.GroupService/RemoveParticipants",
   "/photon.imessage.v1.GroupService/SetDisplayName",
   "/photon.imessage.v1.GroupService/SetIcon",
+  "/photon.imessage.v1.LocationService/RequestLocationSharing",
   "/photon.imessage.v1.MessageService/EditMessage",
   "/photon.imessage.v1.MessageService/NotifySilencedMessage",
   "/photon.imessage.v1.MessageService/PlaceSticker",

--- a/src/types/locations.ts
+++ b/src/types/locations.ts
@@ -20,3 +20,11 @@ export interface SharedFriendLocationUpdated {
   readonly location: SharedFriendLocation;
   readonly sourceSequence: number;
 }
+
+export interface LocationRequestReceipt {
+  readonly address: string;
+  readonly messageGuid?: string;
+  readonly reason?: string;
+  readonly requested: boolean;
+  readonly requestStatus: string;
+}

--- a/tests/unit/locations.test.ts
+++ b/tests/unit/locations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { ValidationError } from "../../src/errors/imessage-error.ts";
 import { FriendLocationType } from "../../src/generated/photon/imessage/v1/location_types.ts";
 import { LocationsResource } from "../../src/resources/locations.ts";
 
@@ -67,5 +68,59 @@ describe("LocationsResource", () => {
     const friend = await resource.get("friend-legacy@example.com");
 
     expect(friend.locationType).toBe("legacy");
+  });
+
+  it("sends a requestLocationSharing request with chat and address", async () => {
+    const requests: Record<string, unknown>[] = [];
+    const resource = new LocationsResource({
+      async requestLocationSharing(request: Record<string, unknown>) {
+        requests.push(request);
+        return {
+          address: "+14155550123",
+          requested: true,
+          requestStatus: "sent",
+          reason: "Find My request card dispatched to Messages",
+          messageGuid: "message-guid",
+        };
+      },
+    } as any);
+
+    const receipt = await resource.request(
+      "any;-;+14155550123",
+      "+14155550123",
+      {
+        clientMessageId: "location-request-1",
+      }
+    );
+
+    expect(requests).toEqual([
+      {
+        address: "+14155550123",
+        chatGuid: "any;-;+14155550123",
+        clientMessageId: "location-request-1",
+      },
+    ]);
+    expect(receipt).toEqual({
+      address: "+14155550123",
+      requested: true,
+      requestStatus: "sent",
+      reason: "Find My request card dispatched to Messages",
+      messageGuid: "message-guid",
+    });
+  });
+
+  it("rejects malformed chat guids before requesting location sharing", async () => {
+    let called = false;
+    const resource = new LocationsResource({
+      async requestLocationSharing() {
+        called = true;
+        return {};
+      },
+    } as any);
+
+    await expect(
+      resource.request("not-a-chat-guid", "+14155550123")
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(called).toBe(false);
   });
 });

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -249,6 +249,30 @@ describe("idempotencyMiddleware", () => {
     expect(receivedMetadata?.get("x-idempotency-key")).toHaveLength(36);
   });
 
+  it("adds x-idempotency-key to location sharing requests", async () => {
+    const mw = idempotencyMiddleware();
+    let receivedMetadata: Metadata | undefined;
+
+    const handler = async (_req: unknown, opts: CallOptions) => {
+      receivedMetadata = opts.metadata as Metadata | undefined;
+      return "ok";
+    };
+
+    const call = buildCall(
+      {
+        ...UNARY_METHOD,
+        path: "/photon.imessage.v1.LocationService/RequestLocationSharing",
+      },
+      {},
+      handler
+    );
+    const gen = mw(call as any, {});
+    const result = await drain(gen);
+
+    expect(result).toBe("ok");
+    expect(receivedMetadata?.get("x-idempotency-key")).toHaveLength(36);
+  });
+
   it("does not add x-idempotency-key to catch-up streams", async () => {
     const mw = idempotencyMiddleware();
     let receivedMetadata: Metadata | undefined;


### PR DESCRIPTION
## Summary
- add the LocationService RequestLocationSharing RPC to the SDK proto contract and generated client
- expose im.locations.request(chat, address, options) with chat GUID validation and idempotency support
- map and export LocationRequestReceipt, with unit coverage for request forwarding and auto-idempotency metadata

## Test plan
- bun run check
- bun test
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request location-sharing from conversations with address and optional client message id.
  * New location request receipt type with address, status, requested flag, and optional reason/message id.
* **Tests**
  * Unit coverage for the location request flow, including validation errors.
  * Middleware test ensuring idempotency header is added for location request calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/advanced-imessage-ts/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->