### PR TITLE
fix: isolate streaming RPCs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -462,17 +462,21 @@ export function createClient(options: ClientOptions): AdvancedIMessage {
     token: options.token,
   });
 
-  const messages = new MessagesImpl(clients.messages);
-  const chats = new ChatsImpl(clients.chats);
+  const messages = new MessagesImpl(clients.messages, clients.messagesStream);
+  const chats = new ChatsImpl(clients.chats, clients.chatsStream);
   const events = new EventsImpl(clients.events);
-  const groups = new GroupsImpl(clients.groups);
-  const attachments = new AttachmentsImpl(clients.attachments);
+  const groups = new GroupsImpl(clients.groups, clients.groupsStream);
+  const attachments = new AttachmentsImpl(
+    clients.attachments,
+    clients.attachmentsStream
+  );
   const addresses = new AddressesImpl(clients.addresses);
-  const polls = new PollsImpl(clients.polls);
-  const locations = new LocationsImpl(clients.locations);
+  const polls = new PollsImpl(clients.polls, clients.pollsStream);
+  const locations = new LocationsImpl(clients.locations, clients.locationsStream);
 
   function close(): Promise<void> {
     clients.channel.close();
+    clients.streamChannel.close();
     return Promise.resolve();
   }
 

--- a/src/resources/attachments.ts
+++ b/src/resources/attachments.ts
@@ -57,9 +57,11 @@ function mapDownloadFrame(
  */
 export class AttachmentsResource {
   private readonly _client: AttachmentServiceClient;
+  private readonly _streamClient: AttachmentServiceClient;
 
-  constructor(client: AttachmentServiceClient) {
+  constructor(client: AttachmentServiceClient, streamClient = client) {
     this._client = client;
+    this._streamClient = streamClient;
   }
 
   /**
@@ -112,7 +114,7 @@ export class AttachmentsResource {
     attachment: string
   ): TypedEventStream<DownloadAttachmentChunk> {
     const abort = new AbortController();
-    const rpcStream = this._client.downloadAttachment(
+    const rpcStream = this._streamClient.downloadAttachment(
       {
         attachmentGuid: attachment,
       },

--- a/src/resources/chats.ts
+++ b/src/resources/chats.ts
@@ -51,9 +51,11 @@ function normalizeInitialMessageText(
  */
 export class ChatsResource {
   private readonly _client: ChatServiceClient;
+  private readonly _streamClient: ChatServiceClient;
 
-  constructor(client: ChatServiceClient) {
+  constructor(client: ChatServiceClient, streamClient = client) {
     this._client = client;
+    this._streamClient = streamClient;
   }
 
   /**
@@ -235,7 +237,7 @@ export class ChatsResource {
    */
   subscribeEvents(filter?: { chat?: string }): TypedEventStream<ChatEvent> {
     const abort = new AbortController();
-    const rpcStream = this._client.subscribeChatEvents(
+    const rpcStream = this._streamClient.subscribeChatEvents(
       {
         chatGuid: filter?.chat ? normalizeChatGuid(filter.chat) : undefined,
       },

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -112,9 +112,11 @@ function normalizeIconData(data: Uint8Array): Uint8Array {
  */
 export class GroupsResource {
   private readonly _client: GroupServiceClient;
+  private readonly _streamClient: GroupServiceClient;
 
-  constructor(client: GroupServiceClient) {
+  constructor(client: GroupServiceClient, streamClient = client) {
     this._client = client;
+    this._streamClient = streamClient;
   }
 
   /**
@@ -272,7 +274,7 @@ export class GroupsResource {
    */
   subscribeEvents(filter?: { chat?: string }): TypedEventStream<GroupEvent> {
     const abort = new AbortController();
-    const rpcStream = this._client.subscribeGroupEvents(
+    const rpcStream = this._streamClient.subscribeGroupEvents(
       {
         chatGuid: filter?.chat ? normalizeChatGuid(filter.chat) : undefined,
       },

--- a/src/resources/locations.ts
+++ b/src/resources/locations.ts
@@ -27,9 +27,11 @@ import { unwrap } from "../utils/unwrap.ts";
  */
 export class LocationsResource {
   private readonly _client: LocationServiceClient;
+  private readonly _streamClient: LocationServiceClient;
 
-  constructor(client: LocationServiceClient) {
+  constructor(client: LocationServiceClient, streamClient = client) {
     this._client = client;
+    this._streamClient = streamClient;
   }
 
   /**
@@ -88,7 +90,7 @@ export class LocationsResource {
   /** Watch updates for every shared friend, or one friend when `address` is set. */
   watch(address?: string): TypedEventStream<SharedFriendLocationUpdated> {
     const abort = new AbortController();
-    const rpcStream = this._client.watchSharedFriendLocations(
+    const rpcStream = this._streamClient.watchSharedFriendLocations(
       { address },
       { signal: abort.signal }
     );

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -82,9 +82,11 @@ function toReactionKind(
  */
 export class MessagesResource {
   private readonly _client: MessageServiceClient;
+  private readonly _streamClient: MessageServiceClient;
 
-  constructor(client: MessageServiceClient) {
+  constructor(client: MessageServiceClient, streamClient = client) {
     this._client = client;
+    this._streamClient = streamClient;
   }
 
   /**
@@ -452,7 +454,7 @@ export class MessagesResource {
    */
   subscribeEvents(filter?: { chat?: string }): TypedEventStream<MessageEvent> {
     const abort = new AbortController();
-    const rpcStream = this._client.subscribeMessageEvents(
+    const rpcStream = this._streamClient.subscribeMessageEvents(
       {
         chatGuid: filter?.chat ? normalizeChatGuid(filter.chat) : undefined,
       },

--- a/src/resources/polls.ts
+++ b/src/resources/polls.ts
@@ -22,9 +22,11 @@ import { unwrap } from "../utils/unwrap.ts";
  */
 export class PollsResource {
   private readonly _client: PollServiceClient;
+  private readonly _streamClient: PollServiceClient;
 
-  constructor(client: PollServiceClient) {
+  constructor(client: PollServiceClient, streamClient = client) {
     this._client = client;
+    this._streamClient = streamClient;
   }
 
   /**
@@ -147,7 +149,7 @@ export class PollsResource {
     pollMessage?: string;
   }): TypedEventStream<PollEvent> {
     const abort = new AbortController();
-    const rpcStream = this._client.subscribePollEvents(
+    const rpcStream = this._streamClient.subscribePollEvents(
       {
         pollMessageGuid: filter?.pollMessage,
       },

--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -60,21 +60,29 @@ export type { PollServiceClient } from "../generated/photon/imessage/v1/poll_ser
 // ---------------------------------------------------------------------------
 
 /**
- * Container for all gRPC service clients and the underlying channel.
+ * Container for all gRPC service clients and the underlying channels.
  *
- * The `channel` is exposed so the caller can close it when done (or use
- * the client's `AsyncDisposable` implementation).
+ * The unary `channel` and streaming `streamChannel` are exposed so the caller
+ * can close them when done (or use the client's `AsyncDisposable`
+ * implementation).
  */
 export interface GrpcClients {
   readonly addresses: AddressServiceClient;
   readonly attachments: AttachmentServiceClient;
+  readonly attachmentsStream: AttachmentServiceClient;
   readonly channel: Channel;
   readonly chats: ChatServiceClient;
+  readonly chatsStream: ChatServiceClient;
   readonly events: EventServiceClient;
   readonly groups: GroupServiceClient;
+  readonly groupsStream: GroupServiceClient;
   readonly locations: LocationServiceClient;
+  readonly locationsStream: LocationServiceClient;
   readonly messages: MessageServiceClient;
+  readonly messagesStream: MessageServiceClient;
   readonly polls: PollServiceClient;
+  readonly pollsStream: PollServiceClient;
+  readonly streamChannel: Channel;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,6 +148,7 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
       : ChannelCredentials.createInsecure();
 
   const channel = createChannel(options.address, credentials);
+  const streamChannel = createChannel(options.address, credentials);
 
   // --- Client factory with middleware ---
   //
@@ -173,13 +182,20 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
   // ts-proto definitions are natively compatible with nice-grpc, no casts needed.
   return {
     messages: factory.create(MessageServiceDefinition, channel),
+    messagesStream: factory.create(MessageServiceDefinition, streamChannel),
     chats: factory.create(ChatServiceDefinition, channel),
-    events: factory.create(EventServiceDefinition, channel),
+    chatsStream: factory.create(ChatServiceDefinition, streamChannel),
+    events: factory.create(EventServiceDefinition, streamChannel),
     groups: factory.create(GroupServiceDefinition, channel),
+    groupsStream: factory.create(GroupServiceDefinition, streamChannel),
     attachments: factory.create(AttachmentServiceDefinition, channel),
+    attachmentsStream: factory.create(AttachmentServiceDefinition, streamChannel),
     addresses: factory.create(AddressServiceDefinition, channel),
     polls: factory.create(PollServiceDefinition, channel),
+    pollsStream: factory.create(PollServiceDefinition, streamChannel),
     locations: factory.create(LocationServiceDefinition, channel),
+    locationsStream: factory.create(LocationServiceDefinition, streamChannel),
     channel,
+    streamChannel,
   };
 }


### PR DESCRIPTION
## Summary
- create a dedicated streaming gRPC channel alongside the existing unary channel
- route every server-streaming SDK API through stream-specific service clients
- close both channels from the top-level client while preserving the public SDK API

## Test plan
- bun run check
- bun test
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781962964&installation_id=127326493&pr_number=31&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F31&signature=1f4364a7b0b9f46f4d2ebf3755dbc7524e8828498e493d3f881f505e8d9aaf66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Implemented dedicated streaming channels for improved performance and reliability of real-time features including event subscriptions, location tracking, and attachment downloads across all resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/advanced-imessage-ts/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->