### PR TITLE
ci(release): opt into npm OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
     with:
       service-name: advanced-imessage
+      use-oidc: true
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "git+https://github.com/photon-hq/advanced-imessage-ts.git"
   },
+  "bugs": {
+    "url": "https://github.com/photon-hq/advanced-imessage-ts/issues"
+  },
   "keywords": [
     "imessage",
     "agent",


### PR DESCRIPTION
## Summary

Moves `advanced-imessage-ts` off the long-lived org `NPM_TOKEN` onto **npm OIDC Trusted Publishing**, so releases authenticate with a per-run GitHub-issued OIDC token instead of a rotating secret. Mirrors photon-hq/spectrum-ts#76 (OIDC opt-in) and #77 (provenance metadata).

## Changes

- **`.github/workflows/release.yaml`**
  - `permissions:` add `id-token: write` (lets the runner mint the OIDC token).
  - `with:` add `use-oidc: true` so buildspace's `typescript-service-release` routes through the OIDC publish job. Confirmed against buildspace `typescript-service-release.yaml` — the OIDC path runs on `inputs.use-oidc == true` and inherits the caller's `id-token: write`; it falls back to `NPM_TOKEN` if OIDC is unavailable, so this is safe.
- **`package.json`**
  - Add `bugs`. Unlike spectrum-ts in #77, this package **already** has `repository.url` (`git+https://github.com/photon-hq/advanced-imessage-ts.git`) and `description` — `repository.url` is the field npm cross-checks against the OIDC-issued repo during provenance verification, so the #77-class `E422` "repository.url is empty" failure can't occur here. No monorepo `directory` field needed (single-package repo). `homepage` omitted — no verified product URL.

## Required pre-merge action on npmjs.com

Trusted Publisher must be configured for `@photon-ai/advanced-imessage` **before** a `release`-labelled merge, otherwise OIDC fails and falls back to the token path:

- Publisher: **GitHub Actions**
- Organization or user: `photon-hq`
- Repository: `advanced-imessage-ts`
- Workflow filename: `release.yaml`
- Environment: *(leave blank)*

(Per the task, npm-side settings are assumed already configured — please confirm the workflow filename matches `release.yaml`.)

## Test plan

- [x] `package.json` validates (`python3 -m json.tool`)
- [x] `release.yaml` parses (ruby YAML)
- [x] `use-oidc` confirmed as a real input on buildspace `typescript-service-release.yaml`
- [ ] Merge without `release` label — confirms workflow still parses on push to main
- [ ] Open a follow-up no-op PR with the `release` label and watch the OIDC publish job run
- [ ] `curl -s https://registry.npmjs.org/@photon-ai/advanced-imessage | jq -r '."dist-tags".latest'` returns the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782269432&installation_id=127326493&pr_number=33&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F33&signature=d398d1ad782642ae2d0f4f832f12f3e1c0fa04b58ad0ecd00509c524bcdfcddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration and package metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/advanced-imessage-ts/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->