### PR TITLE
feat: add customized mini-app message sending

### DIFF
--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -35,6 +35,9 @@ service MessageService {
 
   rpc SendMiniAppMessage(SendMiniAppMessageRequest) returns (MessageResponse);
 
+  // Sends an iMessage mini-app card backed by the caller's own extension.
+  rpc SendCustomizedMiniAppMessage(SendCustomizedMiniAppMessageRequest) returns (MessageResponse);
+
   rpc EditMessage(EditMessageRequest) returns (MessageResponse);
 
   // Retracts an existing message and returns Empty after helper success.
@@ -194,6 +197,81 @@ message MiniAppPreview {
 
   // Fallback text for surfaces that cannot render the full card.
   optional string summary = 8;
+
+}
+
+
+// Visible content of a customized mini-app card. Field names match Apple's
+// `MSMessageTemplateLayout` public API so callers do not need to translate
+// between our names and Apple's docs.
+//
+// Slot map:
+//   * caption/subcaption render on the left;
+//   * trailing_caption/trailing_subcaption render on the right;
+//   * image_title/image_subtitle overlay the image.
+//
+// Validation enforced by the server:
+//   * at least one of {caption, subcaption, trailing_caption,
+//     trailing_subcaption, image} must be non-empty; otherwise the
+//     recipient would see an empty bubble;
+//   * `image` and `image_title` must be set together;
+//   * `image_subtitle` requires `image`.
+message MiniAppLayout {
+
+  // Top-left, bold. The most prominent text slot.
+  optional string caption = 5;
+
+  // Below `caption`, on the left.
+  optional string subcaption = 3;
+
+  // Top-right.
+  optional string trailing_caption = 6;
+
+  // Below `trailing_caption`, on the right.
+  optional string trailing_subcaption = 7;
+
+  // JPEG preview image bytes. Server validates the JPEG SOI marker.
+  optional bytes image = 4;
+
+  // Overlay text shown above the image. Must be set together with `image`.
+  optional string image_title = 1;
+
+  // Overlay text shown below `image_title`, above the image edge.
+  // Requires `image`.
+  optional string image_subtitle = 2;
+
+  // Fallback text shown on surfaces that cannot render the full card.
+  optional string summary = 8;
+
+}
+
+
+// Request for `SendCustomizedMiniAppMessage`.
+message SendCustomizedMiniAppMessageRequest {
+
+  // Target chat GUID.
+  string chat_guid = 1;
+
+  // 10-character uppercase alphanumeric Apple Team ID.
+  string team_id = 2;
+
+  // Bundle identifier of the iMessage extension target.
+  string extension_bundle_id = 3;
+
+  // Human-readable name of the owning app.
+  string app_name = 4;
+
+  // Absolute URL the recipient's installed extension receives on tap.
+  string url = 5;
+
+  // The visible layout of the card. Mirrors Apple's
+  // `MSMessageTemplateLayout`; see `MiniAppLayout` for the rendering map.
+  MiniAppLayout layout = 6;
+
+  // Apple App Store numeric id of the owning app. Required and must be > 0.
+  int64 app_store_id = 7;
+
+  optional string client_message_id = 100;
 
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,13 +36,12 @@ import type {
   SharedFriendLocationUpdated,
 } from "./types/locations.js";
 import type {
+  CustomizedMiniAppMessage,
   EmbeddedMedia,
   Message,
   MessageListFilter,
   MessageListPage,
   MessagePart,
-  MiniAppCard,
-  MiniAppSendOptions,
   SendOptions,
   SettableMessageReaction,
   StickerPlacement,
@@ -210,8 +209,8 @@ export interface LocationsResource {
  *   by GUID with replies, effects, and audio-message mode.
  * - `sendMultipart(chat, parts, options)` sends multiple text / attachment /
  *   mention bubbles atomically.
- * - `sendMiniApp(chat, card, options)` sends a mini app card from a URL and
- *   caller-provided visible preview content.
+ * - `sendCustomizedMiniApp(chat, message, options)` sends a mini app card
+ *   backed by the caller's own iMessage extension.
  * - `edit(chat, message, newText, options)` edits an existing message.
  * - `unsend(chat, message, options)` retracts an existing message.
  * - `setReaction(chat, message, reaction, isSet, options)` adds or removes
@@ -267,10 +266,10 @@ export interface MessagesResource {
       readonly replyTo?: SendOptions["replyTo"];
     }
   ): Promise<Message>;
-  sendMiniApp(
+  sendCustomizedMiniApp(
     chat: string,
-    card: MiniAppCard,
-    options?: MiniAppSendOptions
+    message: CustomizedMiniAppMessage,
+    options?: IdempotencyOptions
   ): Promise<Message>;
   sendMultipart(
     chat: string,
@@ -416,8 +415,8 @@ export interface AdvancedIMessage extends AsyncDisposable {
    *   by GUID with replies, effects, and audio-message mode.
    * - `sendMultipart(chat, parts, options)` sends multiple text / attachment /
    *   mention bubbles atomically.
-   * - `sendMiniApp(chat, card, options)` sends a mini app card from a URL and
-   *   caller-provided visible preview content.
+   * - `sendCustomizedMiniApp(chat, message, options)` sends a mini app card
+   *   backed by the caller's own iMessage extension.
    * - `edit(chat, message, newText, options)` edits an existing message.
    * - `unsend(chat, message, options)` retracts an existing message.
    * - `setReaction(chat, message, reaction, isSet, options)` adds or removes

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -123,6 +123,83 @@ export interface MiniAppPreview {
   summary?: string | undefined;
 }
 
+/**
+ * Visible content of a customized mini-app card. Field names match Apple's
+ * `MSMessageTemplateLayout` public API so callers do not need to translate
+ * between our names and Apple's docs.
+ *
+ * Slot map:
+ *   * caption/subcaption render on the left;
+ *   * trailing_caption/trailing_subcaption render on the right;
+ *   * image_title/image_subtitle overlay the image.
+ *
+ * Validation enforced by the server:
+ *   * at least one of {caption, subcaption, trailing_caption,
+ *     trailing_subcaption, image} must be non-empty; otherwise the
+ *     recipient would see an empty bubble;
+ *   * `image` and `image_title` must be set together;
+ *   * `image_subtitle` requires `image`.
+ */
+export interface MiniAppLayout {
+  /** Top-left, bold. The most prominent text slot. */
+  caption?:
+    | string
+    | undefined;
+  /** Below `caption`, on the left. */
+  subcaption?:
+    | string
+    | undefined;
+  /** Top-right. */
+  trailingCaption?:
+    | string
+    | undefined;
+  /** Below `trailing_caption`, on the right. */
+  trailingSubcaption?:
+    | string
+    | undefined;
+  /** JPEG preview image bytes. Server validates the JPEG SOI marker. */
+  image?:
+    | Uint8Array
+    | undefined;
+  /** Overlay text shown above the image. Must be set together with `image`. */
+  imageTitle?:
+    | string
+    | undefined;
+  /**
+   * Overlay text shown below `image_title`, above the image edge.
+   * Requires `image`.
+   */
+  imageSubtitle?:
+    | string
+    | undefined;
+  /** Fallback text shown on surfaces that cannot render the full card. */
+  summary?: string | undefined;
+}
+
+/** Request for `SendCustomizedMiniAppMessage`. */
+export interface SendCustomizedMiniAppMessageRequest {
+  /** Target chat GUID. */
+  chatGuid: string;
+  /** 10-character uppercase alphanumeric Apple Team ID. */
+  teamId: string;
+  /** Bundle identifier of the iMessage extension target. */
+  extensionBundleId: string;
+  /** Human-readable name of the owning app. */
+  appName: string;
+  /** Absolute URL the recipient's installed extension receives on tap. */
+  url: string;
+  /**
+   * The visible layout of the card. Mirrors Apple's
+   * `MSMessageTemplateLayout`; see `MiniAppLayout` for the rendering map.
+   */
+  layout:
+    | MiniAppLayout
+    | undefined;
+  /** Apple App Store numeric id of the owning app. Required and must be > 0. */
+  appStoreId: number;
+  clientMessageId?: string | undefined;
+}
+
 export interface MessageResponse {
   /**
    * Snapshot of the persisted message after Apple has accepted the send
@@ -1232,6 +1309,410 @@ export const MiniAppPreview: MessageFns<MiniAppPreview> = {
     message.footer = object.footer ?? undefined;
     message.detail = object.detail ?? undefined;
     message.summary = object.summary ?? undefined;
+    return message;
+  },
+};
+
+function createBaseMiniAppLayout(): MiniAppLayout {
+  return {
+    caption: undefined,
+    subcaption: undefined,
+    trailingCaption: undefined,
+    trailingSubcaption: undefined,
+    image: undefined,
+    imageTitle: undefined,
+    imageSubtitle: undefined,
+    summary: undefined,
+  };
+}
+
+export const MiniAppLayout: MessageFns<MiniAppLayout> = {
+  encode(message: MiniAppLayout, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.caption !== undefined) {
+      writer.uint32(42).string(message.caption);
+    }
+    if (message.subcaption !== undefined) {
+      writer.uint32(26).string(message.subcaption);
+    }
+    if (message.trailingCaption !== undefined) {
+      writer.uint32(50).string(message.trailingCaption);
+    }
+    if (message.trailingSubcaption !== undefined) {
+      writer.uint32(58).string(message.trailingSubcaption);
+    }
+    if (message.image !== undefined) {
+      writer.uint32(34).bytes(message.image);
+    }
+    if (message.imageTitle !== undefined) {
+      writer.uint32(10).string(message.imageTitle);
+    }
+    if (message.imageSubtitle !== undefined) {
+      writer.uint32(18).string(message.imageSubtitle);
+    }
+    if (message.summary !== undefined) {
+      writer.uint32(66).string(message.summary);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): MiniAppLayout {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMiniAppLayout();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.caption = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.subcaption = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.trailingCaption = reader.string();
+          continue;
+        }
+        case 7: {
+          if (tag !== 58) {
+            break;
+          }
+
+          message.trailingSubcaption = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.image = reader.bytes();
+          continue;
+        }
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.imageTitle = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.imageSubtitle = reader.string();
+          continue;
+        }
+        case 8: {
+          if (tag !== 66) {
+            break;
+          }
+
+          message.summary = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MiniAppLayout {
+    return {
+      caption: isSet(object.caption) ? globalThis.String(object.caption) : undefined,
+      subcaption: isSet(object.subcaption) ? globalThis.String(object.subcaption) : undefined,
+      trailingCaption: isSet(object.trailingCaption)
+        ? globalThis.String(object.trailingCaption)
+        : isSet(object.trailing_caption)
+        ? globalThis.String(object.trailing_caption)
+        : undefined,
+      trailingSubcaption: isSet(object.trailingSubcaption)
+        ? globalThis.String(object.trailingSubcaption)
+        : isSet(object.trailing_subcaption)
+        ? globalThis.String(object.trailing_subcaption)
+        : undefined,
+      image: isSet(object.image) ? bytesFromBase64(object.image) : undefined,
+      imageTitle: isSet(object.imageTitle)
+        ? globalThis.String(object.imageTitle)
+        : isSet(object.image_title)
+        ? globalThis.String(object.image_title)
+        : undefined,
+      imageSubtitle: isSet(object.imageSubtitle)
+        ? globalThis.String(object.imageSubtitle)
+        : isSet(object.image_subtitle)
+        ? globalThis.String(object.image_subtitle)
+        : undefined,
+      summary: isSet(object.summary) ? globalThis.String(object.summary) : undefined,
+    };
+  },
+
+  toJSON(message: MiniAppLayout): unknown {
+    const obj: any = {};
+    if (message.caption !== undefined) {
+      obj.caption = message.caption;
+    }
+    if (message.subcaption !== undefined) {
+      obj.subcaption = message.subcaption;
+    }
+    if (message.trailingCaption !== undefined) {
+      obj.trailingCaption = message.trailingCaption;
+    }
+    if (message.trailingSubcaption !== undefined) {
+      obj.trailingSubcaption = message.trailingSubcaption;
+    }
+    if (message.image !== undefined) {
+      obj.image = base64FromBytes(message.image);
+    }
+    if (message.imageTitle !== undefined) {
+      obj.imageTitle = message.imageTitle;
+    }
+    if (message.imageSubtitle !== undefined) {
+      obj.imageSubtitle = message.imageSubtitle;
+    }
+    if (message.summary !== undefined) {
+      obj.summary = message.summary;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<MiniAppLayout>): MiniAppLayout {
+    return MiniAppLayout.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<MiniAppLayout>): MiniAppLayout {
+    const message = createBaseMiniAppLayout();
+    message.caption = object.caption ?? undefined;
+    message.subcaption = object.subcaption ?? undefined;
+    message.trailingCaption = object.trailingCaption ?? undefined;
+    message.trailingSubcaption = object.trailingSubcaption ?? undefined;
+    message.image = object.image ?? undefined;
+    message.imageTitle = object.imageTitle ?? undefined;
+    message.imageSubtitle = object.imageSubtitle ?? undefined;
+    message.summary = object.summary ?? undefined;
+    return message;
+  },
+};
+
+function createBaseSendCustomizedMiniAppMessageRequest(): SendCustomizedMiniAppMessageRequest {
+  return {
+    chatGuid: "",
+    teamId: "",
+    extensionBundleId: "",
+    appName: "",
+    url: "",
+    layout: undefined,
+    appStoreId: 0,
+    clientMessageId: undefined,
+  };
+}
+
+export const SendCustomizedMiniAppMessageRequest: MessageFns<SendCustomizedMiniAppMessageRequest> = {
+  encode(message: SendCustomizedMiniAppMessageRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.chatGuid !== "") {
+      writer.uint32(10).string(message.chatGuid);
+    }
+    if (message.teamId !== "") {
+      writer.uint32(18).string(message.teamId);
+    }
+    if (message.extensionBundleId !== "") {
+      writer.uint32(26).string(message.extensionBundleId);
+    }
+    if (message.appName !== "") {
+      writer.uint32(34).string(message.appName);
+    }
+    if (message.url !== "") {
+      writer.uint32(42).string(message.url);
+    }
+    if (message.layout !== undefined) {
+      MiniAppLayout.encode(message.layout, writer.uint32(50).fork()).join();
+    }
+    if (message.appStoreId !== 0) {
+      writer.uint32(56).int64(message.appStoreId);
+    }
+    if (message.clientMessageId !== undefined) {
+      writer.uint32(802).string(message.clientMessageId);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): SendCustomizedMiniAppMessageRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseSendCustomizedMiniAppMessageRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.chatGuid = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.teamId = reader.string();
+          continue;
+        }
+        case 3: {
+          if (tag !== 26) {
+            break;
+          }
+
+          message.extensionBundleId = reader.string();
+          continue;
+        }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.appName = reader.string();
+          continue;
+        }
+        case 5: {
+          if (tag !== 42) {
+            break;
+          }
+
+          message.url = reader.string();
+          continue;
+        }
+        case 6: {
+          if (tag !== 50) {
+            break;
+          }
+
+          message.layout = MiniAppLayout.decode(reader, reader.uint32());
+          continue;
+        }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.appStoreId = longToNumber(reader.int64());
+          continue;
+        }
+        case 100: {
+          if (tag !== 802) {
+            break;
+          }
+
+          message.clientMessageId = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): SendCustomizedMiniAppMessageRequest {
+    return {
+      chatGuid: isSet(object.chatGuid)
+        ? globalThis.String(object.chatGuid)
+        : isSet(object.chat_guid)
+        ? globalThis.String(object.chat_guid)
+        : "",
+      teamId: isSet(object.teamId)
+        ? globalThis.String(object.teamId)
+        : isSet(object.team_id)
+        ? globalThis.String(object.team_id)
+        : "",
+      extensionBundleId: isSet(object.extensionBundleId)
+        ? globalThis.String(object.extensionBundleId)
+        : isSet(object.extension_bundle_id)
+        ? globalThis.String(object.extension_bundle_id)
+        : "",
+      appName: isSet(object.appName)
+        ? globalThis.String(object.appName)
+        : isSet(object.app_name)
+        ? globalThis.String(object.app_name)
+        : "",
+      url: isSet(object.url) ? globalThis.String(object.url) : "",
+      layout: isSet(object.layout) ? MiniAppLayout.fromJSON(object.layout) : undefined,
+      appStoreId: isSet(object.appStoreId)
+        ? globalThis.Number(object.appStoreId)
+        : isSet(object.app_store_id)
+        ? globalThis.Number(object.app_store_id)
+        : 0,
+      clientMessageId: isSet(object.clientMessageId)
+        ? globalThis.String(object.clientMessageId)
+        : isSet(object.client_message_id)
+        ? globalThis.String(object.client_message_id)
+        : undefined,
+    };
+  },
+
+  toJSON(message: SendCustomizedMiniAppMessageRequest): unknown {
+    const obj: any = {};
+    if (message.chatGuid !== "") {
+      obj.chatGuid = message.chatGuid;
+    }
+    if (message.teamId !== "") {
+      obj.teamId = message.teamId;
+    }
+    if (message.extensionBundleId !== "") {
+      obj.extensionBundleId = message.extensionBundleId;
+    }
+    if (message.appName !== "") {
+      obj.appName = message.appName;
+    }
+    if (message.url !== "") {
+      obj.url = message.url;
+    }
+    if (message.layout !== undefined) {
+      obj.layout = MiniAppLayout.toJSON(message.layout);
+    }
+    if (message.appStoreId !== 0) {
+      obj.appStoreId = Math.round(message.appStoreId);
+    }
+    if (message.clientMessageId !== undefined) {
+      obj.clientMessageId = message.clientMessageId;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<SendCustomizedMiniAppMessageRequest>): SendCustomizedMiniAppMessageRequest {
+    return SendCustomizedMiniAppMessageRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<SendCustomizedMiniAppMessageRequest>): SendCustomizedMiniAppMessageRequest {
+    const message = createBaseSendCustomizedMiniAppMessageRequest();
+    message.chatGuid = object.chatGuid ?? "";
+    message.teamId = object.teamId ?? "";
+    message.extensionBundleId = object.extensionBundleId ?? "";
+    message.appName = object.appName ?? "";
+    message.url = object.url ?? "";
+    message.layout = (object.layout !== undefined && object.layout !== null)
+      ? MiniAppLayout.fromPartial(object.layout)
+      : undefined;
+    message.appStoreId = object.appStoreId ?? 0;
+    message.clientMessageId = object.clientMessageId ?? undefined;
     return message;
   },
 };
@@ -2851,6 +3332,15 @@ export const MessageServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    /** Sends an iMessage mini-app card backed by the caller's own extension. */
+    sendCustomizedMiniAppMessage: {
+      name: "SendCustomizedMiniAppMessage",
+      requestType: SendCustomizedMiniAppMessageRequest as typeof SendCustomizedMiniAppMessageRequest,
+      requestStream: false,
+      responseType: MessageResponse as typeof MessageResponse,
+      responseStream: false,
+      options: {},
+    },
     editMessage: {
       name: "EditMessage",
       requestType: EditMessageRequest as typeof EditMessageRequest,
@@ -2959,6 +3449,11 @@ export interface MessageServiceImplementation<CallContextExt = {}> {
     request: SendMiniAppMessageRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<MessageResponse>>;
+  /** Sends an iMessage mini-app card backed by the caller's own extension. */
+  sendCustomizedMiniAppMessage(
+    request: SendCustomizedMiniAppMessageRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<MessageResponse>>;
   editMessage(
     request: EditMessageRequest,
     context: CallContext & CallContextExt,
@@ -3021,6 +3516,11 @@ export interface MessageServiceClient<CallOptionsExt = {}> {
   ): Promise<MessageResponse>;
   sendMiniAppMessage(
     request: DeepPartial<SendMiniAppMessageRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<MessageResponse>;
+  /** Sends an iMessage mini-app card backed by the caller's own extension. */
+  sendCustomizedMiniAppMessage(
+    request: DeepPartial<SendCustomizedMiniAppMessageRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<MessageResponse>;
   editMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export type {
 } from "./types/locations.js";
 // Domain types
 export type {
+  CustomizedMiniAppMessage,
   EmbeddedMedia,
   EmbeddedMediaItem,
   Message,
@@ -86,9 +87,7 @@ export type {
   MessagePart,
   MessagePlacedSticker,
   MessageReaction,
-  MiniAppCard,
-  MiniAppPreview,
-  MiniAppSendOptions,
+  MiniAppLayout,
   SendOptions,
   SettableMessageReaction,
   StickerPlacement,

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -2,6 +2,7 @@ import { fromGrpcError } from "../errors/error-handler.ts";
 import { MessageReactionKind } from "../generated/photon/imessage/v1/message_types.ts";
 import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { MessageServiceClient } from "../transport/grpc-client.ts";
+import type { IdempotencyOptions } from "../types/common.ts";
 import {
   mapEmbeddedMedia,
   mapMessage,
@@ -14,13 +15,12 @@ import { normalizeChatGuid } from "../types/chat-guid.ts";
 import type { MessageEffect } from "../types/effects.ts";
 import type { MessageEvent } from "../types/events.ts";
 import type {
+  CustomizedMiniAppMessage,
   EmbeddedMedia,
   Message,
   MessageListFilter,
   MessageListPage,
   MessagePart,
-  MiniAppCard,
-  MiniAppSendOptions,
   SendOptions,
   SettableMessageReaction,
   StickerPlacement,
@@ -64,8 +64,8 @@ function toReactionKind(
  * - `sendMultipart(chat, parts, options)` sends multiple bubbles atomically;
  *   parts can contain text, uploaded attachment GUIDs, mentions, formatting,
  *   and bubble indexes.
- * - `sendMiniApp(chat, card, options)` sends a mini app card from a URL and
- *   caller-provided visible preview content.
+ * - `sendCustomizedMiniApp(chat, message, options)` sends a mini app card
+ *   backed by the caller's own iMessage extension.
  * - `edit(chat, message, newText, options)` edits an existing message and can
  *   target a specific multipart bubble with `partIndex`.
  * - `unsend(chat, message, options)` retracts an existing message and can
@@ -195,43 +195,44 @@ export class MessagesResource {
   }
 
   /**
-   * Send a mini app card.
+   * Send an iMessage mini-app card backed by the caller's own iMessage
+   * extension.
    *
-   * Recipients open `card.url` when they tap the card. The server prepares the
-   * card for delivery; callers provide only the website URL and visible content.
-   * `card.preview.imageJpeg`, when supplied, must contain JPEG bytes.
+   * The server assembles Apple's balloon plugin id from `teamId` and
+   * `extensionBundleId`. Recipients with the extension installed open it on
+   * tap; others see the App Store entry referenced by `appStoreId`.
+   *
+   * The `layout` field mirrors Apple's `MSMessageTemplateLayout`. At least
+   * one of `caption`, `subcaption`, `trailingCaption`, `trailingSubcaption`,
+   * or `image` must be set, otherwise the card renders as an empty bubble
+   * and is rejected with INVALID_ARGUMENT. `imageTitle` and `imageSubtitle`
+   * are overlay slots that render only when `image` is also set.
    *
    * @param chat - An `any;-;...` or `any;+;...` chat guid. In practice, pass
    *               `chat.guid`.
-   * @param card.url - URL opened when the recipient taps the card.
-   * @param card.preview.title - Required title shown on the card.
-   * @param card.preview.subtitle - Optional secondary text shown on the card.
-   * @param card.preview.body - Optional supporting text shown on the card.
-   * @param card.preview.imageJpeg - Optional JPEG preview image bytes.
-   * @param card.preview.caption - Optional small label shown on the card.
-   * @param card.preview.footer - Optional secondary label shown on the card.
-   * @param card.preview.detail - Optional detail label shown on the card.
-   * @param card.preview.summary - Optional fallback text for limited surfaces.
+   * @param message.teamId - 10-character uppercase alphanumeric Apple Team ID.
+   * @param message.extensionBundleId - Bundle id of the iMessage extension
+   *   target. Must not contain `:`.
+   * @param message.appName - App display name used by Messages fallback UI.
+   * @param message.appStoreId - Positive Apple App Store id of the owning app.
+   * @param message.url - Absolute URL delivered to the extension on tap.
+   * @param message.layout - Visible card layout. See `MiniAppLayout` for the
+   *   rendering map of each slot.
    */
-  async sendMiniApp(
+  async sendCustomizedMiniApp(
     chat: string,
-    card: MiniAppCard,
-    options?: MiniAppSendOptions
+    message: CustomizedMiniAppMessage,
+    options?: IdempotencyOptions
   ): Promise<Message> {
     try {
-      const response = await this._client.sendMiniAppMessage({
+      const response = await this._client.sendCustomizedMiniAppMessage({
         chatGuid: normalizeChatGuid(chat),
-        url: card.url,
-        preview: {
-          title: card.preview.title,
-          subtitle: card.preview.subtitle,
-          body: card.preview.body,
-          imageJpeg: card.preview.imageJpeg,
-          caption: card.preview.caption,
-          footer: card.preview.footer,
-          detail: card.preview.detail,
-          summary: card.preview.summary,
-        },
+        teamId: message.teamId,
+        extensionBundleId: message.extensionBundleId,
+        appName: message.appName,
+        url: message.url,
+        layout: message.layout,
+        appStoreId: message.appStoreId,
         clientMessageId: options?.clientMessageId,
       });
       return mapMessage(unwrap(response.message, "message"));

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -4,7 +4,6 @@
 
 import type { SingleServiceAddressInfo } from "./addresses.js";
 import type { AttachmentInfo } from "./attachments.js";
-import type { IdempotencyOptions } from "./common.js";
 import type { MessageEffect, TextEffect } from "./effects.js";
 import type { MessageItemType } from "./enums.js";
 
@@ -186,33 +185,51 @@ export interface SendOptions {
   readonly subject?: string;
 }
 
-export interface MiniAppPreview {
-  /** Optional supporting text shown on the card. */
-  readonly body?: string;
-  /** Optional small label shown on the card. */
+/**
+ * Visible layout of an iMessage mini-app card. Mirrors Apple's
+ * `MSMessageTemplateLayout`. At least one of `caption`, `subcaption`,
+ * `trailingCaption`, `trailingSubcaption`, or `image` must be set;
+ * an entirely empty layout renders as a blank bubble and is rejected.
+ *
+ * Slot map: `caption` / `subcaption` render on the left,
+ * `trailingCaption` / `trailingSubcaption` render on the right, and
+ * `imageTitle` / `imageSubtitle` overlay `image`.
+ * `image` and `imageTitle` must be set together; `imageSubtitle`
+ * requires `image`.
+ */
+export interface MiniAppLayout {
+  /** Top-left, bold. The most prominent text slot. */
   readonly caption?: string;
-  /** Optional detail label shown on the card. */
-  readonly detail?: string;
-  /** Optional secondary label shown on the card. */
-  readonly footer?: string;
-  /** Optional JPEG preview image bytes. */
-  readonly imageJpeg?: Uint8Array;
-  /** Optional secondary text shown on the card. */
-  readonly subtitle?: string;
-  /** Optional fallback text for surfaces that cannot render the full card. */
+  /** JPEG preview image bytes. */
+  readonly image?: Uint8Array;
+  /** Overlay text shown below `imageTitle`. Requires `image`. */
+  readonly imageSubtitle?: string;
+  /** Overlay text shown above the image. Must be set together with `image`. */
+  readonly imageTitle?: string;
+  /** Below `caption`, on the left. */
+  readonly subcaption?: string;
+  /** Fallback text for surfaces that cannot render the full card. */
   readonly summary?: string;
-  /** Required title shown on the card. */
-  readonly title: string;
+  /** Top-right. */
+  readonly trailingCaption?: string;
+  /** Below `trailingCaption`, on the right. */
+  readonly trailingSubcaption?: string;
 }
 
-export interface MiniAppCard {
-  /** Preview content to show on the card. */
-  readonly preview: MiniAppPreview;
-  /** URL opened when the recipient taps the card. */
+export interface CustomizedMiniAppMessage {
+  /** Display name of the owning app, shown by Messages fallback UI. */
+  readonly appName: string;
+  /** Apple App Store numeric id of the owning app. Must be a positive integer. */
+  readonly appStoreId: number;
+  /** Bundle identifier of the iMessage extension target. Must not contain `:`. */
+  readonly extensionBundleId: string;
+  /** Visible card layout. */
+  readonly layout: MiniAppLayout;
+  /** 10-character uppercase alphanumeric Apple Team ID. */
+  readonly teamId: string;
+  /** Absolute URL delivered to the installed extension on tap. */
   readonly url: string;
 }
-
-export type MiniAppSendOptions = IdempotencyOptions;
 
 export interface MessagePart {
   /** Uploaded attachment guid for an attachment bubble. */

--- a/tests/unit/messages-resource.test.ts
+++ b/tests/unit/messages-resource.test.ts
@@ -214,48 +214,56 @@ describe("MessagesResource", () => {
     expect(captured?.enableDataDetection).toBe(true);
   });
 
-  it("forwards mini app cards using explicit preview fields", async () => {
+  it("forwards customized mini app cards using explicit fields", async () => {
     let captured: Record<string, unknown> | undefined;
     const resource = new MessagesResource({
-      async sendMiniAppMessage(request: Record<string, unknown>) {
+      async sendCustomizedMiniAppMessage(request: Record<string, unknown>) {
         captured = request;
-        return { message: makeMessage("mini-app") };
+        return { message: makeMessage("customized-mini-app") };
       },
     } as any);
-    const imageJpeg = new Uint8Array([0xff, 0xd8, 0xff]);
+    const image = new Uint8Array([0xff, 0xd8, 0xff]);
 
-    await resource.sendMiniApp(
+    await resource.sendCustomizedMiniApp(
       chatGuidValue,
       {
-        url: "https://example.com/demo",
-        preview: {
-          title: "Example Website",
-          subtitle: "example.com",
-          body: "Open the demo",
-          imageJpeg,
-          caption: "Demo",
-          footer: "Photon",
-          detail: "Updated now",
-          summary: "Example Website",
+        teamId: "TEAMID1234",
+        extensionBundleId: "com.example.app.MessagesExtension",
+        appName: "Example",
+        appStoreId: 1_234_567_890,
+        url: "exampleapp://card/42",
+        layout: {
+          caption: "Card Title",
+          subcaption: "example.com",
+          trailingCaption: "trail",
+          trailingSubcaption: "trail sub",
+          image,
+          imageTitle: "Overlay title",
+          imageSubtitle: "Overlay subtitle",
+          summary: "Card summary",
         },
       },
-      { clientMessageId: "tmp-mini-app-1" }
+      { clientMessageId: "tmp-customized-mini-app-1" }
     );
 
     expect(captured).toEqual({
       chatGuid: chatGuidValue,
-      url: "https://example.com/demo",
-      preview: {
-        title: "Example Website",
-        subtitle: "example.com",
-        body: "Open the demo",
-        imageJpeg,
-        caption: "Demo",
-        footer: "Photon",
-        detail: "Updated now",
-        summary: "Example Website",
+      teamId: "TEAMID1234",
+      extensionBundleId: "com.example.app.MessagesExtension",
+      appName: "Example",
+      appStoreId: 1_234_567_890,
+      url: "exampleapp://card/42",
+      layout: {
+        caption: "Card Title",
+        subcaption: "example.com",
+        trailingCaption: "trail",
+        trailingSubcaption: "trail sub",
+        image,
+        imageTitle: "Overlay title",
+        imageSubtitle: "Overlay subtitle",
+        summary: "Card summary",
       },
-      clientMessageId: "tmp-mini-app-1",
+      clientMessageId: "tmp-customized-mini-app-1",
     });
   });
 


### PR DESCRIPTION
## Summary

- Replaces the original `sendMiniApp(chat, card, options)` surface with `sendCustomizedMiniApp(chat, message, options)` (breaking)
- Adds `CustomizedMiniAppMessage` / `MiniAppLayout` types mirroring Apple's `MSMessageTemplateLayout` slot map
- Regenerates proto / gRPC bindings for `SendCustomizedMiniAppMessage`
- Updates the resource-level unit test to cover the new shape

## Breaking change

`sendMiniApp(...)` is removed. Direct SDK consumers must migrate to `sendCustomizedMiniApp(...)`; the field surface now mirrors Apple's `MSMessageTemplateLayout` (caption / subcaption / trailingCaption / trailingSubcaption / image / imageTitle / imageSubtitle / summary).

## Cross-repo

Depends on companion PRs in `spectrum-ts`, `spectrum-imessage`, and `advanced-imessage-server-v2#94`.

## Test plan

- [ ] `bun test` passes
- [ ] Manual end-to-end send via `messages.sendCustomizedMiniApp(...)` directly against a running server

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782488211&installation_id=127326493&pr_number=34&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F34&signature=b9ef77f5a03545b4397d64675e4b88e0e523d616db71a829e4e720079a50b2b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customized mini-app messages with flexible layout templates. Messages can now display rich card layouts with configurable text elements including caption, subcaption, and trailing text, along with visual components such as images with overlay support. These capabilities enable richer interactive mini-app messaging experiences across chats and team conversations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/advanced-imessage-ts/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->