### PR TITLE
refactor: drop chat parameter from messages.get

### DIFF
--- a/examples/messages/get.ts
+++ b/examples/messages/get.ts
@@ -6,10 +6,9 @@ const im = createClient({
   tls: false,
 });
 
-const chat = "any;-;alice@example.com";
 const messageGuid = "message-guid";
 
-const message = await im.messages.get(chat, messageGuid);
+const message = await im.messages.get(messageGuid);
 
 console.log("guid:", message.guid);
 console.log("text:", message.content.text);

--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -358,10 +358,6 @@ message NotifySilencedMessageRequest {
 
 message GetMessageRequest {
 
-  // Visibility scope. The server uses `chat_guid` to authorise the read and
-  // to disambiguate cross-chat duplicates.
-  string chat_guid = 1;
-
   string message_guid = 2;
 
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -219,7 +219,7 @@ export interface LocationsResource {
  *   uploaded sticker attachment on a message.
  * - `notifySilenced(chat, message, options)` triggers Apple's Notify Anyway
  *   action for a Focus-silenced conversation.
- * - `get(chat, message)` fetches one message inside a known chat.
+ * - `get(message)` fetches one message by its guid.
  * - `listRecent(filter)` pages through recent messages across chats.
  * - `listInChat(chat, filter)` pages through messages in one chat.
  * - `getEmbeddedMedia(chat, message)` downloads Digital Touch / handwritten
@@ -237,7 +237,7 @@ export interface MessagesResource {
       readonly partIndex?: number;
     }
   ): Promise<Message>;
-  get(chat: string, message: string): Promise<Message>;
+  get(message: string): Promise<Message>;
   getEmbeddedMedia(chat: string, message: string): Promise<EmbeddedMedia>;
   listInChat(
     chat: string,
@@ -425,7 +425,7 @@ export interface AdvancedIMessage extends AsyncDisposable {
    *   uploaded sticker attachment on a message.
    * - `notifySilenced(chat, message, options)` triggers Apple's Notify Anyway
    *   action for a Focus-silenced conversation.
-   * - `get(chat, message)` fetches one message inside a known chat.
+   * - `get(message)` fetches one message by its guid.
    * - `listRecent(filter)` pages through recent messages across chats.
    * - `listInChat(chat, filter)` pages through messages in one chat.
    * - `getEmbeddedMedia(chat, message)` downloads Digital Touch / handwritten

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -251,11 +251,6 @@ export interface NotifySilencedMessageRequest {
 }
 
 export interface GetMessageRequest {
-  /**
-   * Visibility scope. The server uses `chat_guid` to authorise the read and
-   * to disambiguate cross-chat duplicates.
-   */
-  chatGuid: string;
   messageGuid: string;
 }
 
@@ -2324,14 +2319,11 @@ export const NotifySilencedMessageRequest: MessageFns<NotifySilencedMessageReque
 };
 
 function createBaseGetMessageRequest(): GetMessageRequest {
-  return { chatGuid: "", messageGuid: "" };
+  return { messageGuid: "" };
 }
 
 export const GetMessageRequest: MessageFns<GetMessageRequest> = {
   encode(message: GetMessageRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.chatGuid !== "") {
-      writer.uint32(10).string(message.chatGuid);
-    }
     if (message.messageGuid !== "") {
       writer.uint32(18).string(message.messageGuid);
     }
@@ -2345,14 +2337,6 @@ export const GetMessageRequest: MessageFns<GetMessageRequest> = {
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        case 1: {
-          if (tag !== 10) {
-            break;
-          }
-
-          message.chatGuid = reader.string();
-          continue;
-        }
         case 2: {
           if (tag !== 18) {
             break;
@@ -2372,11 +2356,6 @@ export const GetMessageRequest: MessageFns<GetMessageRequest> = {
 
   fromJSON(object: any): GetMessageRequest {
     return {
-      chatGuid: isSet(object.chatGuid)
-        ? globalThis.String(object.chatGuid)
-        : isSet(object.chat_guid)
-        ? globalThis.String(object.chat_guid)
-        : "",
       messageGuid: isSet(object.messageGuid)
         ? globalThis.String(object.messageGuid)
         : isSet(object.message_guid)
@@ -2387,9 +2366,6 @@ export const GetMessageRequest: MessageFns<GetMessageRequest> = {
 
   toJSON(message: GetMessageRequest): unknown {
     const obj: any = {};
-    if (message.chatGuid !== "") {
-      obj.chatGuid = message.chatGuid;
-    }
     if (message.messageGuid !== "") {
       obj.messageGuid = message.messageGuid;
     }
@@ -2401,7 +2377,6 @@ export const GetMessageRequest: MessageFns<GetMessageRequest> = {
   },
   fromPartial(object: DeepPartial<GetMessageRequest>): GetMessageRequest {
     const message = createBaseGetMessageRequest();
-    message.chatGuid = object.chatGuid ?? "";
     message.messageGuid = object.messageGuid ?? "";
     return message;
   },

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -76,7 +76,7 @@ function toReactionKind(
  *   uploaded sticker attachment on a message.
  * - `notifySilenced(chat, message, options)` triggers Apple's Notify Anyway
  *   action for a Focus-silenced conversation.
- * - `get(chat, message)` fetches one message inside a known chat.
+ * - `get(message)` fetches one message by its guid.
  * - `listRecent(filter)` pages through recent messages across chats.
  * - `listInChat(chat, filter)` pages through messages in one chat.
  * - `getEmbeddedMedia(chat, message)` downloads Digital Touch / handwritten
@@ -396,16 +396,13 @@ export class MessagesResource {
   }
 
   /**
-   * Fetch a single message by its guid within a known chat.
+   * Fetch a single message by its guid.
    *
-   * @param chat - An `any;-;...` or `any;+;...` chat guid. In practice, pass
-   *               `chat.guid`.
    * @param message - Guid of the message to fetch (`message.guid`).
    */
-  async get(chat: string, message: string): Promise<Message> {
+  async get(message: string): Promise<Message> {
     try {
       const response = await this._client.getMessage({
-        chatGuid: normalizeChatGuid(chat),
         messageGuid: message,
       });
       return mapMessage(unwrap(response.message, "message"));


### PR DESCRIPTION
## Summary

`messages.get(chat, message)` becomes `messages.get(message)`.

## Why

The `chat_guid` field on `GetMessageRequest` was never used by the server: `message_guid` is globally unique in chat.db and the DB query path looked up by message_guid only. Companion server change: photon-hq/advanced-imessage-server-v2#95.

## Breaking change

This is a breaking API change for any caller of `messages.get`. All other resource methods are unchanged.

## Changes

- Proto: drop `chat_guid` from `GetMessageRequest`.
- `MessagesResource.get(message)` — single argument.
- `AdvancedIMessage` / `MessagesResource` interface updated; docstrings adjusted.
- Example `examples/messages/get.ts` updated.
- Regenerated `src/generated/photon/imessage/v1/message_service.ts`.

## Test plan

- [x] `bun run build`
- [x] `bun test` (128 tests pass)
- [ ] Publish coordinated with server rollout before consumers upgrade.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782542250&installation_id=127326493&pr_number=35&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F35&signature=41204bf156f42571c05e72af0c3cb7f69cc14df4329e182fa022b66380e159d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified message retrieval: fetch messages by GUID alone without requiring a chat identifier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/advanced-imessage-ts/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->