### PR TITLE
feat: make customized mini app store id optional

### DIFF
--- a/proto/photon/imessage/v1/message_service.proto
+++ b/proto/photon/imessage/v1/message_service.proto
@@ -268,8 +268,8 @@ message SendCustomizedMiniAppMessageRequest {
   // `MSMessageTemplateLayout`; see `MiniAppLayout` for the rendering map.
   MiniAppLayout layout = 6;
 
-  // Apple App Store numeric id of the owning app. Required and must be > 0.
-  int64 app_store_id = 7;
+  // Apple App Store numeric id of the owning app. When set, must be > 0.
+  optional int64 app_store_id = 7;
 
   optional string client_message_id = 100;
 

--- a/src/generated/photon/imessage/v1/message_service.ts
+++ b/src/generated/photon/imessage/v1/message_service.ts
@@ -195,8 +195,8 @@ export interface SendCustomizedMiniAppMessageRequest {
   layout:
     | MiniAppLayout
     | undefined;
-  /** Apple App Store numeric id of the owning app. Required and must be > 0. */
-  appStoreId: number;
+  /** Apple App Store numeric id of the owning app. When set, must be > 0. */
+  appStoreId?: number | undefined;
   clientMessageId?: string | undefined;
 }
 
@@ -1513,7 +1513,7 @@ function createBaseSendCustomizedMiniAppMessageRequest(): SendCustomizedMiniAppM
     appName: "",
     url: "",
     layout: undefined,
-    appStoreId: 0,
+    appStoreId: undefined,
     clientMessageId: undefined,
   };
 }
@@ -1538,7 +1538,7 @@ export const SendCustomizedMiniAppMessageRequest: MessageFns<SendCustomizedMiniA
     if (message.layout !== undefined) {
       MiniAppLayout.encode(message.layout, writer.uint32(50).fork()).join();
     }
-    if (message.appStoreId !== 0) {
+    if (message.appStoreId !== undefined) {
       writer.uint32(56).int64(message.appStoreId);
     }
     if (message.clientMessageId !== undefined) {
@@ -1655,7 +1655,7 @@ export const SendCustomizedMiniAppMessageRequest: MessageFns<SendCustomizedMiniA
         ? globalThis.Number(object.appStoreId)
         : isSet(object.app_store_id)
         ? globalThis.Number(object.app_store_id)
-        : 0,
+        : undefined,
       clientMessageId: isSet(object.clientMessageId)
         ? globalThis.String(object.clientMessageId)
         : isSet(object.client_message_id)
@@ -1684,7 +1684,7 @@ export const SendCustomizedMiniAppMessageRequest: MessageFns<SendCustomizedMiniA
     if (message.layout !== undefined) {
       obj.layout = MiniAppLayout.toJSON(message.layout);
     }
-    if (message.appStoreId !== 0) {
+    if (message.appStoreId !== undefined) {
       obj.appStoreId = Math.round(message.appStoreId);
     }
     if (message.clientMessageId !== undefined) {
@@ -1706,7 +1706,7 @@ export const SendCustomizedMiniAppMessageRequest: MessageFns<SendCustomizedMiniA
     message.layout = (object.layout !== undefined && object.layout !== null)
       ? MiniAppLayout.fromPartial(object.layout)
       : undefined;
-    message.appStoreId = object.appStoreId ?? 0;
+    message.appStoreId = object.appStoreId ?? undefined;
     message.clientMessageId = object.clientMessageId ?? undefined;
     return message;
   },

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -200,7 +200,8 @@ export class MessagesResource {
    *
    * The server assembles Apple's balloon plugin id from `teamId` and
    * `extensionBundleId`. Recipients with the extension installed open it on
-   * tap; others see the App Store entry referenced by `appStoreId`.
+   * tap; others see the App Store entry referenced by `appStoreId` when it is
+   * set.
    *
    * The `layout` field mirrors Apple's `MSMessageTemplateLayout`. At least
    * one of `caption`, `subcaption`, `trailingCaption`, `trailingSubcaption`,
@@ -214,7 +215,8 @@ export class MessagesResource {
    * @param message.extensionBundleId - Bundle id of the iMessage extension
    *   target. Must not contain `:`.
    * @param message.appName - App display name used by Messages fallback UI.
-   * @param message.appStoreId - Positive Apple App Store id of the owning app.
+   * @param message.appStoreId - Optional positive Apple App Store id of the
+   *   owning app.
    * @param message.url - Absolute URL delivered to the extension on tap.
    * @param message.layout - Visible card layout. See `MiniAppLayout` for the
    *   rendering map of each slot.

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -219,8 +219,8 @@ export interface MiniAppLayout {
 export interface CustomizedMiniAppMessage {
   /** Display name of the owning app, shown by Messages fallback UI. */
   readonly appName: string;
-  /** Apple App Store numeric id of the owning app. Must be a positive integer. */
-  readonly appStoreId: number;
+  /** Apple App Store numeric id of the owning app. When set, must be a positive integer. */
+  readonly appStoreId?: number;
   /** Bundle identifier of the iMessage extension target. Must not contain `:`. */
   readonly extensionBundleId: string;
   /** Visible card layout. */

--- a/tests/unit/messages-resource.test.ts
+++ b/tests/unit/messages-resource.test.ts
@@ -267,6 +267,38 @@ describe("MessagesResource", () => {
     });
   });
 
+  it("does not default appStoreId for customized mini app cards when unset", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const resource = new MessagesResource({
+      async sendCustomizedMiniAppMessage(request: Record<string, unknown>) {
+        captured = request;
+        return { message: makeMessage("customized-mini-app-no-store") };
+      },
+    } as any);
+
+    await resource.sendCustomizedMiniApp(chatGuidValue, {
+      teamId: "TEAMID1234",
+      extensionBundleId: "com.example.app.MessagesExtension",
+      appName: "Example",
+      url: "exampleapp://card/42",
+      layout: {
+        caption: "Card Title",
+      },
+    });
+
+    expect(captured).toMatchObject({
+      chatGuid: chatGuidValue,
+      teamId: "TEAMID1234",
+      extensionBundleId: "com.example.app.MessagesExtension",
+      appName: "Example",
+      url: "exampleapp://card/42",
+      layout: {
+        caption: "Card Title",
+      },
+    });
+    expect(captured?.appStoreId).toBeUndefined();
+  });
+
   describe("TextFormatInput → wire formatting (exhaustive)", () => {
     for (const type of [
       "bold",


### PR DESCRIPTION
## Summary
- make customized mini app app_store_id optional in the generated RPC type
- allow SDK callers to omit appStoreId
- keep unset appStoreId as undefined instead of defaulting it to 0

## Tests
- bun run check
- bun test tests/unit/messages-resource.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782793969&installation_id=127326493&pr_number=36&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F36&signature=03a65a9b905a3f25cb7693d22a91ab0a7f7f244cd59ad161f71fe3c361bf43eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified App Store fallback behavior: recipients without the iMessage extension only see the fallback when appStoreId is explicitly set.

* **Refactor**
  * Made appStoreId optional for customized mini app messages, removing it as a mandatory field.

* **Tests**
  * Added unit test verifying the appStoreId field is omitted when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->