### PR TITLE
fix: raise gRPC channel message limit to 100MB

### DIFF
--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -9,6 +9,7 @@
 
 import {
   type Channel,
+  type ChannelOptions,
   ChannelCredentials,
   createChannel,
   createClientFactory,
@@ -127,6 +128,14 @@ export interface GrpcClientOptions {
 // ---------------------------------------------------------------------------
 
 /**
+ * Maximum size (in bytes) of a single gRPC message in either direction,
+ * sized to match the 100 MB backend request limit so attachment uploads and
+ * downloads can use the full payload. `@grpc/grpc-js` otherwise defaults to
+ * 4 MB on receive and unlimited on send.
+ */
+const MAX_MESSAGE_BYTES = 100 * 1024 * 1024;
+
+/**
  * Create a gRPC channel and all service clients with the configured
  * middleware.
  *
@@ -147,8 +156,17 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
       ? ChannelCredentials.createSsl()
       : ChannelCredentials.createInsecure();
 
-  const channel = createChannel(options.address, credentials);
-  const streamChannel = createChannel(options.address, credentials);
+  const channelOptions: ChannelOptions = {
+    "grpc.max_receive_message_length": MAX_MESSAGE_BYTES,
+    "grpc.max_send_message_length": MAX_MESSAGE_BYTES,
+  };
+
+  const channel = createChannel(options.address, credentials, channelOptions);
+  const streamChannel = createChannel(
+    options.address,
+    credentials,
+    channelOptions
+  );
 
   // --- Client factory with middleware ---
   //


### PR DESCRIPTION
## Summary
- `@grpc/grpc-js` defaults receive to 4MB, which rejects attachment uploads and downloads above that boundary (this is the root cause of recent `RESOURCE_EXHAUSTED` reports from SDK consumers).
- Set 100MB on both the unary and stream channels (`grpc.max_receive_message_length` + `grpc.max_send_message_length`) to match the backend server cap.

## Test plan
- [x] End-to-end through spectrum-ts → SDK → Swift server: sequential `1MB / 10MB / 50MB / 99MB` uploads + `5×10MB` concurrent — all passed with payloads physically landing on disk.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782885341&installation_id=127326493&pr_number=37&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F37&signature=a02dc75cf6afa2907701c4b1cd65e37e7628a3187dc7cd971e03b81c724a4062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased gRPC message size limits to 100 MiB for both incoming and outgoing communications, enabling the system to handle larger data transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->