### PR TITLE
fix: align location rpc with server (RequestFriendLocationSharing)

### DIFF
--- a/proto/photon/imessage/v1/location_service.proto
+++ b/proto/photon/imessage/v1/location_service.proto
@@ -23,8 +23,8 @@ service LocationService {
   rpc GetSharedFriendLocation(GetSharedFriendLocationRequest)
       returns (GetSharedFriendLocationResponse);
 
-  rpc RequestLocationSharing(RequestLocationSharingRequest)
-      returns (RequestLocationSharingResponse);
+  rpc RequestFriendLocationSharing(RequestFriendLocationSharingRequest)
+      returns (RequestFriendLocationSharingResponse);
 
   rpc WatchSharedFriendLocations(WatchSharedFriendLocationsRequest)
       returns (stream WatchSharedFriendLocationsResponse);
@@ -69,12 +69,13 @@ message GetSharedFriendLocationResponse {
 // Mutations
 // ---------------------------------------------------------------------------
 
-// Sends a visible Find My location-sharing request card in `chat_guid`.
+// Sends a visible Find My request card to `address` in `chat_guid`.
+// `address` must be a participant in the chat.
 //
 // Errors:
-//   INVALID_ARGUMENT  malformed address or chat_guid
+//   INVALID_ARGUMENT  malformed address/chat_guid, or address is not in chat
 //   NOT_FOUND         chat is not visible to the current account
-message RequestLocationSharingRequest {
+message RequestFriendLocationSharingRequest {
 
   string chat_guid = 1;
 
@@ -85,17 +86,15 @@ message RequestLocationSharingRequest {
 }
 
 
-message RequestLocationSharingResponse {
+message RequestFriendLocationSharingResponse {
 
   string address = 1;
 
-  bool requested = 2;
+  string status = 2;
 
-  string request_status = 3;
+  optional string reason = 3;
 
-  optional string reason = 4;
-
-  optional string message_guid = 5;
+  optional string message_guid = 4;
 
 }
 

--- a/src/generated/photon/imessage/v1/location_service.ts
+++ b/src/generated/photon/imessage/v1/location_service.ts
@@ -35,22 +35,22 @@ export interface GetSharedFriendLocationResponse {
 }
 
 /**
- * Sends a visible Find My location-sharing request card in `chat_guid`.
+ * Sends a visible Find My request card to `address` in `chat_guid`.
+ * `address` must be a participant in the chat.
  *
  * Errors:
- *   INVALID_ARGUMENT  malformed address or chat_guid
+ *   INVALID_ARGUMENT  malformed address/chat_guid, or address is not in chat
  *   NOT_FOUND         chat is not visible to the current account
  */
-export interface RequestLocationSharingRequest {
+export interface RequestFriendLocationSharingRequest {
   chatGuid: string;
   address: string;
   clientMessageId?: string | undefined;
 }
 
-export interface RequestLocationSharingResponse {
+export interface RequestFriendLocationSharingResponse {
   address: string;
-  requested: boolean;
-  requestStatus: string;
+  status: string;
   reason?: string | undefined;
   messageGuid?: string | undefined;
 }
@@ -291,12 +291,12 @@ export const GetSharedFriendLocationResponse: MessageFns<GetSharedFriendLocation
   },
 };
 
-function createBaseRequestLocationSharingRequest(): RequestLocationSharingRequest {
+function createBaseRequestFriendLocationSharingRequest(): RequestFriendLocationSharingRequest {
   return { chatGuid: "", address: "", clientMessageId: undefined };
 }
 
-export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingRequest> = {
-  encode(message: RequestLocationSharingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+export const RequestFriendLocationSharingRequest: MessageFns<RequestFriendLocationSharingRequest> = {
+  encode(message: RequestFriendLocationSharingRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.chatGuid !== "") {
       writer.uint32(10).string(message.chatGuid);
     }
@@ -309,10 +309,10 @@ export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingReq
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): RequestLocationSharingRequest {
+  decode(input: BinaryReader | Uint8Array, length?: number): RequestFriendLocationSharingRequest {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRequestLocationSharingRequest();
+    const message = createBaseRequestFriendLocationSharingRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -349,7 +349,7 @@ export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingReq
     return message;
   },
 
-  fromJSON(object: any): RequestLocationSharingRequest {
+  fromJSON(object: any): RequestFriendLocationSharingRequest {
     return {
       chatGuid: isSet(object.chatGuid)
         ? globalThis.String(object.chatGuid)
@@ -365,7 +365,7 @@ export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingReq
     };
   },
 
-  toJSON(message: RequestLocationSharingRequest): unknown {
+  toJSON(message: RequestFriendLocationSharingRequest): unknown {
     const obj: any = {};
     if (message.chatGuid !== "") {
       obj.chatGuid = message.chatGuid;
@@ -379,11 +379,11 @@ export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingReq
     return obj;
   },
 
-  create(base?: DeepPartial<RequestLocationSharingRequest>): RequestLocationSharingRequest {
-    return RequestLocationSharingRequest.fromPartial(base ?? {});
+  create(base?: DeepPartial<RequestFriendLocationSharingRequest>): RequestFriendLocationSharingRequest {
+    return RequestFriendLocationSharingRequest.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<RequestLocationSharingRequest>): RequestLocationSharingRequest {
-    const message = createBaseRequestLocationSharingRequest();
+  fromPartial(object: DeepPartial<RequestFriendLocationSharingRequest>): RequestFriendLocationSharingRequest {
+    const message = createBaseRequestFriendLocationSharingRequest();
     message.chatGuid = object.chatGuid ?? "";
     message.address = object.address ?? "";
     message.clientMessageId = object.clientMessageId ?? undefined;
@@ -391,34 +391,31 @@ export const RequestLocationSharingRequest: MessageFns<RequestLocationSharingReq
   },
 };
 
-function createBaseRequestLocationSharingResponse(): RequestLocationSharingResponse {
-  return { address: "", requested: false, requestStatus: "", reason: undefined, messageGuid: undefined };
+function createBaseRequestFriendLocationSharingResponse(): RequestFriendLocationSharingResponse {
+  return { address: "", status: "", reason: undefined, messageGuid: undefined };
 }
 
-export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingResponse> = {
-  encode(message: RequestLocationSharingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+export const RequestFriendLocationSharingResponse: MessageFns<RequestFriendLocationSharingResponse> = {
+  encode(message: RequestFriendLocationSharingResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.address !== "") {
       writer.uint32(10).string(message.address);
     }
-    if (message.requested !== false) {
-      writer.uint32(16).bool(message.requested);
-    }
-    if (message.requestStatus !== "") {
-      writer.uint32(26).string(message.requestStatus);
+    if (message.status !== "") {
+      writer.uint32(18).string(message.status);
     }
     if (message.reason !== undefined) {
-      writer.uint32(34).string(message.reason);
+      writer.uint32(26).string(message.reason);
     }
     if (message.messageGuid !== undefined) {
-      writer.uint32(42).string(message.messageGuid);
+      writer.uint32(34).string(message.messageGuid);
     }
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): RequestLocationSharingResponse {
+  decode(input: BinaryReader | Uint8Array, length?: number): RequestFriendLocationSharingResponse {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseRequestLocationSharingResponse();
+    const message = createBaseRequestFriendLocationSharingResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -431,11 +428,11 @@ export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingRe
           continue;
         }
         case 2: {
-          if (tag !== 16) {
+          if (tag !== 18) {
             break;
           }
 
-          message.requested = reader.bool();
+          message.status = reader.string();
           continue;
         }
         case 3: {
@@ -443,19 +440,11 @@ export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingRe
             break;
           }
 
-          message.requestStatus = reader.string();
+          message.reason = reader.string();
           continue;
         }
         case 4: {
           if (tag !== 34) {
-            break;
-          }
-
-          message.reason = reader.string();
-          continue;
-        }
-        case 5: {
-          if (tag !== 42) {
             break;
           }
 
@@ -471,15 +460,10 @@ export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingRe
     return message;
   },
 
-  fromJSON(object: any): RequestLocationSharingResponse {
+  fromJSON(object: any): RequestFriendLocationSharingResponse {
     return {
       address: isSet(object.address) ? globalThis.String(object.address) : "",
-      requested: isSet(object.requested) ? globalThis.Boolean(object.requested) : false,
-      requestStatus: isSet(object.requestStatus)
-        ? globalThis.String(object.requestStatus)
-        : isSet(object.request_status)
-        ? globalThis.String(object.request_status)
-        : "",
+      status: isSet(object.status) ? globalThis.String(object.status) : "",
       reason: isSet(object.reason) ? globalThis.String(object.reason) : undefined,
       messageGuid: isSet(object.messageGuid)
         ? globalThis.String(object.messageGuid)
@@ -489,16 +473,13 @@ export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingRe
     };
   },
 
-  toJSON(message: RequestLocationSharingResponse): unknown {
+  toJSON(message: RequestFriendLocationSharingResponse): unknown {
     const obj: any = {};
     if (message.address !== "") {
       obj.address = message.address;
     }
-    if (message.requested !== false) {
-      obj.requested = message.requested;
-    }
-    if (message.requestStatus !== "") {
-      obj.requestStatus = message.requestStatus;
+    if (message.status !== "") {
+      obj.status = message.status;
     }
     if (message.reason !== undefined) {
       obj.reason = message.reason;
@@ -509,14 +490,13 @@ export const RequestLocationSharingResponse: MessageFns<RequestLocationSharingRe
     return obj;
   },
 
-  create(base?: DeepPartial<RequestLocationSharingResponse>): RequestLocationSharingResponse {
-    return RequestLocationSharingResponse.fromPartial(base ?? {});
+  create(base?: DeepPartial<RequestFriendLocationSharingResponse>): RequestFriendLocationSharingResponse {
+    return RequestFriendLocationSharingResponse.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<RequestLocationSharingResponse>): RequestLocationSharingResponse {
-    const message = createBaseRequestLocationSharingResponse();
+  fromPartial(object: DeepPartial<RequestFriendLocationSharingResponse>): RequestFriendLocationSharingResponse {
+    const message = createBaseRequestFriendLocationSharingResponse();
     message.address = object.address ?? "";
-    message.requested = object.requested ?? false;
-    message.requestStatus = object.requestStatus ?? "";
+    message.status = object.status ?? "";
     message.reason = object.reason ?? undefined;
     message.messageGuid = object.messageGuid ?? undefined;
     return message;
@@ -691,11 +671,11 @@ export const LocationServiceDefinition = {
       responseStream: false,
       options: {},
     },
-    requestLocationSharing: {
-      name: "RequestLocationSharing",
-      requestType: RequestLocationSharingRequest as typeof RequestLocationSharingRequest,
+    requestFriendLocationSharing: {
+      name: "RequestFriendLocationSharing",
+      requestType: RequestFriendLocationSharingRequest as typeof RequestFriendLocationSharingRequest,
       requestStream: false,
-      responseType: RequestLocationSharingResponse as typeof RequestLocationSharingResponse,
+      responseType: RequestFriendLocationSharingResponse as typeof RequestFriendLocationSharingResponse,
       responseStream: false,
       options: {},
     },
@@ -719,10 +699,10 @@ export interface LocationServiceImplementation<CallContextExt = {}> {
     request: GetSharedFriendLocationRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<GetSharedFriendLocationResponse>>;
-  requestLocationSharing(
-    request: RequestLocationSharingRequest,
+  requestFriendLocationSharing(
+    request: RequestFriendLocationSharingRequest,
     context: CallContext & CallContextExt,
-  ): Promise<DeepPartial<RequestLocationSharingResponse>>;
+  ): Promise<DeepPartial<RequestFriendLocationSharingResponse>>;
   watchSharedFriendLocations(
     request: WatchSharedFriendLocationsRequest,
     context: CallContext & CallContextExt,
@@ -738,10 +718,10 @@ export interface LocationServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<GetSharedFriendLocationRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<GetSharedFriendLocationResponse>;
-  requestLocationSharing(
-    request: DeepPartial<RequestLocationSharingRequest>,
+  requestFriendLocationSharing(
+    request: DeepPartial<RequestFriendLocationSharingRequest>,
     options?: CallOptions & CallOptionsExt,
-  ): Promise<RequestLocationSharingResponse>;
+  ): Promise<RequestFriendLocationSharingResponse>;
   watchSharedFriendLocations(
     request: DeepPartial<WatchSharedFriendLocationsRequest>,
     options?: CallOptions & CallOptionsExt,

--- a/src/resources/locations.ts
+++ b/src/resources/locations.ts
@@ -76,7 +76,7 @@ export class LocationsResource {
     options: IdempotencyOptions = {}
   ): Promise<LocationRequestReceipt> {
     try {
-      const response = await this._client.requestLocationSharing({
+      const response = await this._client.requestFriendLocationSharing({
         address,
         chatGuid: normalizeChatGuid(chat),
         clientMessageId: options.clientMessageId,

--- a/src/transport/mapper.ts
+++ b/src/transport/mapper.ts
@@ -14,7 +14,7 @@ import type {
   ChatChangeEvent as ProtoChatChangeEvent,
 } from "../generated/photon/imessage/v1/chat_types.ts";
 import type { GroupChangeEvent as ProtoGroupChangeEvent } from "../generated/photon/imessage/v1/group_types.ts";
-import type { RequestLocationSharingResponse as ProtoRequestLocationSharingResponse } from "../generated/photon/imessage/v1/location_service.ts";
+import type { RequestFriendLocationSharingResponse as ProtoRequestFriendLocationSharingResponse } from "../generated/photon/imessage/v1/location_service.ts";
 import {
   FriendLocationType as ProtoFriendLocationType,
   type SharedFriendLocation as ProtoSharedFriendLocation,
@@ -478,14 +478,13 @@ export function mapSharedFriendLocationUpdated(
 }
 
 export function mapLocationRequestReceipt(
-  proto: ProtoRequestLocationSharingResponse
+  proto: ProtoRequestFriendLocationSharingResponse
 ): LocationRequestReceipt {
   return {
     address: proto.address,
     messageGuid: proto.messageGuid,
     reason: proto.reason,
-    requested: proto.requested,
-    requestStatus: proto.requestStatus,
+    status: proto.status,
   };
 }
 

--- a/src/transport/metadata.ts
+++ b/src/transport/metadata.ts
@@ -63,7 +63,7 @@ const MUTATING_METHODS: ReadonlySet<string> = new Set([
   "/photon.imessage.v1.GroupService/RemoveParticipants",
   "/photon.imessage.v1.GroupService/SetDisplayName",
   "/photon.imessage.v1.GroupService/SetIcon",
-  "/photon.imessage.v1.LocationService/RequestLocationSharing",
+  "/photon.imessage.v1.LocationService/RequestFriendLocationSharing",
   "/photon.imessage.v1.MessageService/EditMessage",
   "/photon.imessage.v1.MessageService/NotifySilencedMessage",
   "/photon.imessage.v1.MessageService/PlaceSticker",

--- a/src/types/locations.ts
+++ b/src/types/locations.ts
@@ -25,6 +25,5 @@ export interface LocationRequestReceipt {
   readonly address: string;
   readonly messageGuid?: string;
   readonly reason?: string;
-  readonly requested: boolean;
-  readonly requestStatus: string;
+  readonly status: string;
 }

--- a/tests/unit/locations.test.ts
+++ b/tests/unit/locations.test.ts
@@ -70,15 +70,14 @@ describe("LocationsResource", () => {
     expect(friend.locationType).toBe("legacy");
   });
 
-  it("sends a requestLocationSharing request with chat and address", async () => {
+  it("sends a requestFriendLocationSharing request with chat and address", async () => {
     const requests: Record<string, unknown>[] = [];
     const resource = new LocationsResource({
-      async requestLocationSharing(request: Record<string, unknown>) {
+      async requestFriendLocationSharing(request: Record<string, unknown>) {
         requests.push(request);
         return {
           address: "+14155550123",
-          requested: true,
-          requestStatus: "sent",
+          status: "sent",
           reason: "Find My request card dispatched to Messages",
           messageGuid: "message-guid",
         };
@@ -102,8 +101,7 @@ describe("LocationsResource", () => {
     ]);
     expect(receipt).toEqual({
       address: "+14155550123",
-      requested: true,
-      requestStatus: "sent",
+      status: "sent",
       reason: "Find My request card dispatched to Messages",
       messageGuid: "message-guid",
     });
@@ -112,7 +110,7 @@ describe("LocationsResource", () => {
   it("rejects malformed chat guids before requesting location sharing", async () => {
     let called = false;
     const resource = new LocationsResource({
-      async requestLocationSharing() {
+      async requestFriendLocationSharing() {
         called = true;
         return {};
       },

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -261,7 +261,7 @@ describe("idempotencyMiddleware", () => {
     const call = buildCall(
       {
         ...UNARY_METHOD,
-        path: "/photon.imessage.v1.LocationService/RequestLocationSharing",
+        path: "/photon.imessage.v1.LocationService/RequestFriendLocationSharing",
       },
       {},
       handler


### PR DESCRIPTION
## Summary
- Rename `RequestLocationSharing` → `RequestFriendLocationSharing` across proto, generated code, resources, transport metadata/mapper, and types — aligning the SDK with the server contract (`photon.imessage.v1.LocationService`).
- Replace the response shape `requested: bool` / `requestStatus: string` with the server's single `status: string` field (proto tags `address=1, status=2, reason=3, message_guid=4`).

## Why
Calls to `LocationService/RequestLocationSharing` failed with gRPC `UNIMPLEMENTED` because the server only registers `RequestFriendLocationSharing`. The SDK's proto had drifted from the server's source of truth. `location_service.proto` is now byte-identical to the server (modulo local import path style).

## Test plan
- [x] `bun test` — 129 pass / 0 fail
- [x] Full-project residue scan (src + tests + proto) — 0 references to old symbols
- [x] `bun run generate` regenerated; old RPC name absent, new name present

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782965466&installation_id=127326493&pr_number=38&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F38&signature=5c81950f7652a2c800c29688d0721fa85479ed2895f3371b1db01e8ef89868fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced location sharing request functionality with refined error handling for Find My requests and improved scenario validation
  * Better detection of invalid states including chat visibility and address issues with appropriate error messaging
  * Streamlined request status response that provides clearer feedback to users
  * Increased reliability and improved user experience across location sharing features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->