### PR TITLE
Add gRPC client keepalive and surface stream heartbeats (ENG-1691)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,10 @@ import { LocationsResource as LocationsImpl } from "./resources/locations.js";
 import { MessagesResource as MessagesImpl } from "./resources/messages.js";
 import { PollsResource as PollsImpl } from "./resources/polls.js";
 import type { TypedEventStream } from "./streaming/event-stream.js";
-import { createGrpcClients } from "./transport/grpc-client.js";
+import {
+  createGrpcClients,
+  type GrpcChannelOptions,
+} from "./transport/grpc-client.js";
 import type { MultiServiceAddressInfo } from "./types/addresses.js";
 import type {
   AttachmentInfo,
@@ -21,7 +24,11 @@ import type {
   CreateChatOptions,
   CreateChatResult,
 } from "./types/chats.js";
-import type { IdempotencyOptions, RetryOptions } from "./types/common.js";
+import type {
+  HeartbeatHandler,
+  IdempotencyOptions,
+  RetryOptions,
+} from "./types/common.js";
 import type { MessageEffect } from "./types/effects.js";
 import type {
   CatchUpEvent,
@@ -54,6 +61,21 @@ export interface ClientOptions {
   readonly address: string;
   /** When `true`, adds an `x-idempotency-key` header to mutating RPCs. */
   readonly autoIdempotency?: boolean;
+  /**
+   * Extra `@grpc/grpc-js` channel options merged onto (and able to override)
+   * the SDK defaults — including the built-in keepalive settings — for both
+   * the unary and streaming channels. Tune keepalive here, e.g.
+   * `{ "grpc.keepalive_time_ms": 15000 }`, without waiting for an SDK release.
+   */
+  readonly channelOptions?: GrpcChannelOptions;
+  /**
+   * Called once for every server heartbeat frame on any `subscribeEvents` /
+   * `watch` stream. The server emits heartbeats on a fixed cadence even when
+   * idle, so this is a liveness signal: drive a stall watchdog from it to
+   * detect a half-open connection and re-establish the stream. Without it,
+   * heartbeat frames are silently dropped.
+   */
+  readonly onHeartbeat?: HeartbeatHandler;
   /** Retries retryable unary RPC failures; streaming RPCs are never retried automatically. */
   readonly retry?: boolean | RetryOptions;
   /** Default unary RPC timeout in milliseconds; streaming RPCs are left open. */
@@ -466,25 +488,36 @@ export function createClient(options: ClientOptions): AdvancedIMessage {
   const clients = createGrpcClients({
     address: options.address,
     autoIdempotency: options.autoIdempotency,
+    channelOptions: options.channelOptions,
     retry: options.retry,
     timeout: options.timeout,
     tls: options.tls,
     token: options.token,
   });
 
-  const messages = new MessagesImpl(clients.messages, clients.messagesStream);
-  const chats = new ChatsImpl(clients.chats, clients.chatsStream);
+  const onHeartbeat = options.onHeartbeat;
+  const messages = new MessagesImpl(
+    clients.messages,
+    clients.messagesStream,
+    onHeartbeat
+  );
+  const chats = new ChatsImpl(clients.chats, clients.chatsStream, onHeartbeat);
   const events = new EventsImpl(clients.events);
-  const groups = new GroupsImpl(clients.groups, clients.groupsStream);
+  const groups = new GroupsImpl(
+    clients.groups,
+    clients.groupsStream,
+    onHeartbeat
+  );
   const attachments = new AttachmentsImpl(
     clients.attachments,
     clients.attachmentsStream
   );
   const addresses = new AddressesImpl(clients.addresses);
-  const polls = new PollsImpl(clients.polls, clients.pollsStream);
+  const polls = new PollsImpl(clients.polls, clients.pollsStream, onHeartbeat);
   const locations = new LocationsImpl(
     clients.locations,
-    clients.locationsStream
+    clients.locationsStream,
+    onHeartbeat
   );
 
   function close(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export {
 export type { GroupIcon } from "./resources/groups.js";
 // Streaming
 export { TypedEventStream } from "./streaming/event-stream.js";
+// Transport
+export type { GrpcChannelOptions } from "./transport/grpc-client.js";
 export type {
   MultiServiceAddressInfo,
   SingleServiceAddressInfo,
@@ -45,7 +47,11 @@ export type {
   CreateChatResult,
 } from "./types/chats.js";
 // Common
-export type { IdempotencyOptions, RetryOptions } from "./types/common.js";
+export type {
+  HeartbeatHandler,
+  IdempotencyOptions,
+  RetryOptions,
+} from "./types/common.js";
 // Effects
 export { MessageEffect, TextEffect } from "./types/effects.js";
 // Enums

--- a/src/resources/chats.ts
+++ b/src/resources/chats.ts
@@ -10,6 +10,7 @@ import type {
   CreateChatOptions,
   CreateChatResult,
 } from "../types/chats.ts";
+import type { HeartbeatHandler } from "../types/common.ts";
 import type { ChatEvent } from "../types/events.ts";
 import { unwrap } from "../utils/unwrap.ts";
 
@@ -52,10 +53,16 @@ function normalizeInitialMessageText(
 export class ChatsResource {
   private readonly _client: ChatServiceClient;
   private readonly _streamClient: ChatServiceClient;
+  private readonly _onHeartbeat: HeartbeatHandler | undefined;
 
-  constructor(client: ChatServiceClient, streamClient = client) {
+  constructor(
+    client: ChatServiceClient,
+    streamClient = client,
+    onHeartbeat?: HeartbeatHandler
+  ) {
     this._client = client;
     this._streamClient = streamClient;
+    this._onHeartbeat = onHeartbeat;
   }
 
   /**
@@ -237,6 +244,7 @@ export class ChatsResource {
    */
   subscribeEvents(filter?: { chat?: string }): TypedEventStream<ChatEvent> {
     const abort = new AbortController();
+    const onHeartbeat = this._onHeartbeat;
     const rpcStream = this._streamClient.subscribeChatEvents(
       {
         chatGuid: filter?.chat ? normalizeChatGuid(filter.chat) : undefined,
@@ -248,6 +256,9 @@ export class ChatsResource {
       try {
         for await (const frame of rpcStream) {
           if (frame.sequence === undefined || !frame.chatChanged) {
+            if (frame.heartbeat) {
+              onHeartbeat?.();
+            }
             continue;
           }
           const event = mapChatEvent(frame.sequence, frame.chatChanged);

--- a/src/resources/groups.ts
+++ b/src/resources/groups.ts
@@ -5,7 +5,7 @@ import type { GroupServiceClient } from "../transport/grpc-client.ts";
 import { mapChat, mapGroupEvent } from "../transport/mapper.ts";
 import { normalizeChatGuid } from "../types/chat-guid.ts";
 import type { Chat } from "../types/chats.ts";
-import type { IdempotencyOptions } from "../types/common.ts";
+import type { HeartbeatHandler, IdempotencyOptions } from "../types/common.ts";
 import type { GroupEvent } from "../types/events.ts";
 import { unwrap } from "../utils/unwrap.ts";
 
@@ -113,10 +113,16 @@ function normalizeIconData(data: Uint8Array): Uint8Array {
 export class GroupsResource {
   private readonly _client: GroupServiceClient;
   private readonly _streamClient: GroupServiceClient;
+  private readonly _onHeartbeat: HeartbeatHandler | undefined;
 
-  constructor(client: GroupServiceClient, streamClient = client) {
+  constructor(
+    client: GroupServiceClient,
+    streamClient = client,
+    onHeartbeat?: HeartbeatHandler
+  ) {
     this._client = client;
     this._streamClient = streamClient;
+    this._onHeartbeat = onHeartbeat;
   }
 
   /**
@@ -274,6 +280,7 @@ export class GroupsResource {
    */
   subscribeEvents(filter?: { chat?: string }): TypedEventStream<GroupEvent> {
     const abort = new AbortController();
+    const onHeartbeat = this._onHeartbeat;
     const rpcStream = this._streamClient.subscribeGroupEvents(
       {
         chatGuid: filter?.chat ? normalizeChatGuid(filter.chat) : undefined,
@@ -285,6 +292,9 @@ export class GroupsResource {
       try {
         for await (const frame of rpcStream) {
           if (frame.sequence === undefined || !frame.groupChanged) {
+            if (frame.heartbeat) {
+              onHeartbeat?.();
+            }
             continue;
           }
           const event = mapGroupEvent(frame.sequence, frame.groupChanged);

--- a/src/resources/locations.ts
+++ b/src/resources/locations.ts
@@ -7,7 +7,7 @@ import {
   mapSharedFriendLocationUpdated,
 } from "../transport/mapper.ts";
 import { normalizeChatGuid } from "../types/chat-guid.ts";
-import type { IdempotencyOptions } from "../types/common.ts";
+import type { HeartbeatHandler, IdempotencyOptions } from "../types/common.ts";
 import type {
   LocationRequestReceipt,
   SharedFriendLocation,
@@ -28,10 +28,16 @@ import { unwrap } from "../utils/unwrap.ts";
 export class LocationsResource {
   private readonly _client: LocationServiceClient;
   private readonly _streamClient: LocationServiceClient;
+  private readonly _onHeartbeat: HeartbeatHandler | undefined;
 
-  constructor(client: LocationServiceClient, streamClient = client) {
+  constructor(
+    client: LocationServiceClient,
+    streamClient = client,
+    onHeartbeat?: HeartbeatHandler
+  ) {
     this._client = client;
     this._streamClient = streamClient;
+    this._onHeartbeat = onHeartbeat;
   }
 
   /**
@@ -90,6 +96,7 @@ export class LocationsResource {
   /** Watch updates for every shared friend, or one friend when `address` is set. */
   watch(address?: string): TypedEventStream<SharedFriendLocationUpdated> {
     const abort = new AbortController();
+    const onHeartbeat = this._onHeartbeat;
     const rpcStream = this._streamClient.watchSharedFriendLocations(
       { address },
       { signal: abort.signal }
@@ -99,6 +106,9 @@ export class LocationsResource {
       try {
         for await (const frame of rpcStream) {
           if (!frame.locationUpdated) {
+            if (frame.heartbeat) {
+              onHeartbeat?.();
+            }
             continue;
           }
           yield mapSharedFriendLocationUpdated(frame.locationUpdated);

--- a/src/resources/messages.ts
+++ b/src/resources/messages.ts
@@ -2,7 +2,6 @@ import { fromGrpcError } from "../errors/error-handler.ts";
 import { MessageReactionKind } from "../generated/photon/imessage/v1/message_types.ts";
 import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { MessageServiceClient } from "../transport/grpc-client.ts";
-import type { IdempotencyOptions } from "../types/common.ts";
 import {
   mapEmbeddedMedia,
   mapMessage,
@@ -12,6 +11,7 @@ import {
   mapTextFormatInput,
 } from "../transport/mapper.ts";
 import { normalizeChatGuid } from "../types/chat-guid.ts";
+import type { HeartbeatHandler, IdempotencyOptions } from "../types/common.ts";
 import type { MessageEffect } from "../types/effects.ts";
 import type { MessageEvent } from "../types/events.ts";
 import type {
@@ -87,10 +87,16 @@ function toReactionKind(
 export class MessagesResource {
   private readonly _client: MessageServiceClient;
   private readonly _streamClient: MessageServiceClient;
+  private readonly _onHeartbeat: HeartbeatHandler | undefined;
 
-  constructor(client: MessageServiceClient, streamClient = client) {
+  constructor(
+    client: MessageServiceClient,
+    streamClient = client,
+    onHeartbeat?: HeartbeatHandler
+  ) {
     this._client = client;
     this._streamClient = streamClient;
+    this._onHeartbeat = onHeartbeat;
   }
 
   /**
@@ -504,6 +510,7 @@ export class MessagesResource {
    */
   subscribeEvents(filter?: { chat?: string }): TypedEventStream<MessageEvent> {
     const abort = new AbortController();
+    const onHeartbeat = this._onHeartbeat;
     const rpcStream = this._streamClient.subscribeMessageEvents(
       {
         chatGuid: filter?.chat ? normalizeChatGuid(filter.chat) : undefined,
@@ -515,6 +522,9 @@ export class MessagesResource {
       try {
         for await (const frame of rpcStream) {
           if (frame.sequence === undefined || !frame.messageChanged) {
+            if (frame.heartbeat) {
+              onHeartbeat?.();
+            }
             continue;
           }
           const event = mapMessageEvent(frame.sequence, frame.messageChanged);

--- a/src/resources/polls.ts
+++ b/src/resources/polls.ts
@@ -3,7 +3,7 @@ import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { PollServiceClient } from "../transport/grpc-client.ts";
 import { mapPoll, mapPollEvent } from "../transport/mapper.ts";
 import { normalizeChatGuid } from "../types/chat-guid.ts";
-import type { IdempotencyOptions } from "../types/common.ts";
+import type { HeartbeatHandler, IdempotencyOptions } from "../types/common.ts";
 import type { PollEvent } from "../types/events.ts";
 import type { Poll } from "../types/polls.ts";
 import { unwrap } from "../utils/unwrap.ts";
@@ -23,10 +23,16 @@ import { unwrap } from "../utils/unwrap.ts";
 export class PollsResource {
   private readonly _client: PollServiceClient;
   private readonly _streamClient: PollServiceClient;
+  private readonly _onHeartbeat: HeartbeatHandler | undefined;
 
-  constructor(client: PollServiceClient, streamClient = client) {
+  constructor(
+    client: PollServiceClient,
+    streamClient = client,
+    onHeartbeat?: HeartbeatHandler
+  ) {
     this._client = client;
     this._streamClient = streamClient;
+    this._onHeartbeat = onHeartbeat;
   }
 
   /**
@@ -149,6 +155,7 @@ export class PollsResource {
     pollMessage?: string;
   }): TypedEventStream<PollEvent> {
     const abort = new AbortController();
+    const onHeartbeat = this._onHeartbeat;
     const rpcStream = this._streamClient.subscribePollEvents(
       {
         pollMessageGuid: filter?.pollMessage,
@@ -160,6 +167,9 @@ export class PollsResource {
       try {
         for await (const frame of rpcStream) {
           if (frame.sequence === undefined || !frame.pollChanged) {
+            if (frame.heartbeat) {
+              onHeartbeat?.();
+            }
             continue;
           }
           const event = mapPollEvent(frame.sequence, frame.pollChanged);

--- a/src/transport/grpc-client.ts
+++ b/src/transport/grpc-client.ts
@@ -9,8 +9,8 @@
 
 import {
   type Channel,
-  type ChannelOptions,
   ChannelCredentials,
+  type ChannelOptions,
   createChannel,
   createClientFactory,
 } from "nice-grpc";
@@ -48,6 +48,11 @@ import {
 // client interfaces have correct method signatures for nice-grpc usage.
 // ---------------------------------------------------------------------------
 
+/**
+ * `@grpc/grpc-js` channel options. Re-exported so callers can type custom
+ * channel/keepalive overrides without importing from `nice-grpc` directly.
+ */
+export type { ChannelOptions as GrpcChannelOptions } from "nice-grpc";
 export type { AddressServiceClient } from "../generated/photon/imessage/v1/address_service.ts";
 export type { AttachmentServiceClient } from "../generated/photon/imessage/v1/attachment_service.ts";
 export type { ChatServiceClient } from "../generated/photon/imessage/v1/chat_service.ts";
@@ -100,6 +105,13 @@ export interface GrpcClientOptions {
    */
   autoIdempotency?: boolean;
   /**
+   * Additional `@grpc/grpc-js` channel options merged onto (and able to
+   * override) the SDK defaults for both the unary and streaming channels.
+   * Use this to tune keepalive — e.g. `grpc.keepalive_time_ms` — without
+   * waiting for an SDK release.
+   */
+  channelOptions?: ChannelOptions;
+  /**
    * Enable automatic retry with exponential backoff for retryable errors.
    * Pass `true` for default settings, or a `RetryOptions` object to
    * customise the behaviour.
@@ -136,6 +148,28 @@ export interface GrpcClientOptions {
 const MAX_MESSAGE_BYTES = 100 * 1024 * 1024;
 
 /**
+ * How often (ms) the client sends an HTTP/2 keepalive PING when no other
+ * data is in flight. Chosen to match the server's ~30s heartbeat cadence and
+ * to stay above the server-side minimum ping interval, so the client never
+ * trips a GOAWAY `too_many_pings`. Lets a half-open connection (a silent
+ * gateway drop with no RST/GOAWAY) be detected within
+ * `keepalive_time_ms + keepalive_timeout_ms` instead of stalling forever.
+ */
+const KEEPALIVE_TIME_MS = 30_000;
+
+/**
+ * How long (ms) the client waits for a keepalive PING ACK before declaring
+ * the connection dead and tearing it down.
+ */
+const KEEPALIVE_TIMEOUT_MS = 20_000;
+
+/** Send keepalive pings even when there are no active RPC calls (`1` = on). */
+const KEEPALIVE_PERMIT_WITHOUT_CALLS = 1;
+
+/** Allow unlimited keepalive pings without data in flight (`0` = no cap). */
+const KEEPALIVE_MAX_PINGS_WITHOUT_DATA = 0;
+
+/**
  * Create a gRPC channel and all service clients with the configured
  * middleware.
  *
@@ -156,9 +190,18 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
       ? ChannelCredentials.createSsl()
       : ChannelCredentials.createInsecure();
 
+  // Keepalive lets clients detect a half-open connection (failure mode 2 of
+  // ENG-1688): a silent gateway drop that sends no RST/GOAWAY would otherwise
+  // leave the event `for await` blocked forever. Applied to BOTH channels.
+  // Caller-supplied `channelOptions` win, so liveness stays tunable.
   const channelOptions: ChannelOptions = {
     "grpc.max_receive_message_length": MAX_MESSAGE_BYTES,
     "grpc.max_send_message_length": MAX_MESSAGE_BYTES,
+    "grpc.keepalive_time_ms": KEEPALIVE_TIME_MS,
+    "grpc.keepalive_timeout_ms": KEEPALIVE_TIMEOUT_MS,
+    "grpc.keepalive_permit_without_calls": KEEPALIVE_PERMIT_WITHOUT_CALLS,
+    "grpc.http2.max_pings_without_data": KEEPALIVE_MAX_PINGS_WITHOUT_DATA,
+    ...options.channelOptions,
   };
 
   const channel = createChannel(options.address, credentials, channelOptions);

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -17,3 +17,16 @@ export interface IdempotencyOptions {
   /** Stable key for one logical write. Reuse it only when retrying that same write. */
   readonly clientMessageId?: string;
 }
+
+/**
+ * Invoked once for every server heartbeat frame received on any
+ * `subscribeEvents` / `watch` stream.
+ *
+ * The server emits heartbeats on a fixed cadence (~30s) even when no domain
+ * events occur. Consumers can use this signal to run a stall watchdog: if no
+ * heartbeat arrives within a grace window, the connection is likely half-open
+ * and the stream should be torn down and re-established. Without this hook the
+ * heartbeat frames are silently dropped and a half-open stall is undetectable
+ * from the event stream alone.
+ */
+export type HeartbeatHandler = () => void;


### PR DESCRIPTION
## Summary

Clients had no way to detect a half-open gRPC connection, so a server/gateway drop that delivers no RST/GOAWAY left the event `for await` blocked forever (latent half-open stall; failure mode 2 of ENG-1688). Two gaps in `createGrpcClients` caused this, and `ClientOptions` exposed no way to tune liveness. This PR closes both.

### Changes

1. **Keepalive on both channels.** `channelOptions` previously set only `grpc.max_receive/send_message_length`. Added HTTP/2 keepalive to **both** the unary `channel` and the `streamChannel`:
   - `grpc.keepalive_time_ms`: 30000
   - `grpc.keepalive_timeout_ms`: 20000
   - `grpc.keepalive_permit_without_calls`: 1
   - `grpc.http2.max_pings_without_data`: 0

   A half-open connection is now detected within `keepalive_time_ms + keepalive_timeout_ms` instead of stalling forever. `keepalive_time_ms` is set to 30s to match the server's ~30s heartbeat cadence and stay above the server-side minimum ping interval, avoiding a GOAWAY `too_many_pings` (the repo ships no explicit server min-ping constant to align to, so 30s + `permit_without_calls` is the standard safe choice).

2. **Surface heartbeat frames.** The `subscribeEvents` / `watch` map loops (messages, chats, groups, polls, locations) silently dropped heartbeat frames. They now invoke an optional `onHeartbeat` hook when a heartbeat frame arrives, so consumers can drive a stall watchdog.

3. **Public configuration.** Exposed `channelOptions` and `onHeartbeat` on `ClientOptions` (caller-supplied channel options override the SDK keepalive defaults), plus exported the `HeartbeatHandler` and `GrpcChannelOptions` types — so spectrum-ts can configure liveness without waiting for another SDK release.

### Transport note

origin/main ships the nice-grpc + @grpc/grpc-js transport (confirmed by reading the code), which is what published 0.11.2 consumers use; the `refactor/connect-grpc-web` branch was ignored as instructed. Keepalive is applied via `channelOptions` accordingly.

### Verification

- `tsc --noEmit` — clean
- `biome check src/` — clean (33 files)
- `tsup` build — success (dist is gitignored / built at publish time, so not committed)
- `bun test tests/unit` — 129 pass, 0 fail

Part of ENG-1688. Closes ENG-1691.

https://claude.ai/code/session_01AFkXpowryHpuBtqEgMMFaC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784878026&installation_id=127326493&pr_number=40&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F40&signature=6323b90b3dc8dccf0afb19af17d1a8418a76ec79bb7bf252fea4a0af999cd2b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->