### PR TITLE
feat: expose catch-up event decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,22 @@ for await (const event of im.messages.subscribeEvents({ chat: chatGuid })) {
 }
 ```
 
+Transport adapters that already receive an encoded
+`CatchUpEventsResponse` frame can map it through the same public event model
+without importing generated protobuf internals:
+
+```ts
+import { decodeCatchUpEvent } from "@photon-ai/advanced-imessage";
+
+const event = decodeCatchUpEvent(frameBytes);
+if (event?.type === "message.received") {
+  console.log(event.message.guid);
+}
+```
+
+Heartbeat and payload-less frames return `undefined`; errors reported by the
+generated protobuf decoder propagate to the caller.
+
 Every `subscribeEvents(...)`, `downloadStream(...)`, and `locations.watch(...)`
 call returns a `TypedEventStream<T>`. Streams support `for await`, `.on(...)`,
 `.filter(...)`, `.map(...)`, `.take(...)`, `.close()`, and `await using`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   ValidationError,
 } from "./errors/imessage-error.js";
 // Resource type re-exports
+export { decodeCatchUpEvent } from "./resources/events.js";
 export type { GroupIcon } from "./resources/groups.js";
 // Streaming
 export { TypedEventStream } from "./streaming/event-stream.js";

--- a/src/resources/events.ts
+++ b/src/resources/events.ts
@@ -1,5 +1,6 @@
 import { fromGrpcError } from "../errors/error-handler.ts";
 import { ValidationError } from "../errors/imessage-error.ts";
+import { CatchUpEventsResponse } from "../generated/photon/imessage/v1/event_service.ts";
 import { TypedEventStream } from "../streaming/event-stream.ts";
 import type { EventServiceClient } from "../transport/grpc-client.ts";
 import {
@@ -30,14 +31,9 @@ function normalizeSequenceCursor(
   return cursor;
 }
 
-function mapCatchUpFrame(frame: {
-  complete?: { headSequence: number };
-  sequence?: number;
-  messageChanged?: Parameters<typeof mapMessageEvent>[1];
-  chatChanged?: Parameters<typeof mapChatEvent>[1];
-  groupChanged?: Parameters<typeof mapGroupEvent>[1];
-  pollChanged?: Parameters<typeof mapPollEvent>[1];
-}): CatchUpEvent | undefined {
+function mapCatchUpFrame(
+  frame: CatchUpEventsResponse
+): CatchUpEvent | undefined {
   if (frame.complete) {
     return {
       type: "catchup.complete",
@@ -66,6 +62,20 @@ function mapCatchUpFrame(frame: {
   }
 
   return undefined;
+}
+
+/**
+ * Decode one protobuf `CatchUpEventsResponse` frame into the same high-level
+ * event shape returned by `events.catchUp()`.
+ *
+ * Heartbeats, sequence-only frames, and frames without a recognized event
+ * payload return `undefined`. Errors from the generated protobuf decoder
+ * propagate to the caller.
+ */
+export function decodeCatchUpEvent(
+  bytes: Uint8Array
+): CatchUpEvent | undefined {
+  return mapCatchUpFrame(CatchUpEventsResponse.decode(bytes));
 }
 
 /**

--- a/tests/unit/events-resource.test.ts
+++ b/tests/unit/events-resource.test.ts
@@ -1,5 +1,84 @@
 import { describe, expect, it } from "bun:test";
+import { CatchUpEventsResponse } from "../../src/generated/photon/imessage/v1/event_service.ts";
+import { decodeCatchUpEvent } from "../../src/index.ts";
 import { EventsResource } from "../../src/resources/events.ts";
+
+const RECEIVED_AT = new Date("2026-07-16T01:02:03.456Z");
+
+// Produced by fusor-fanin-imessage's independent protobufjs delivery transform.
+// Keeping the bytes fixed catches field-number drift between the two repos.
+const FUSOR_RECEIVED_FRAME = Uint8Array.from(
+  Buffer.from(
+    "CCpSuwEKF2lNZXNzYWdlOy07KzE1NTUxMjM0NTY3EgwIi9vg0gYQgIS42QEaFAoMKzE1NTUxMjM0NTY3EAEaAlVTUnwKegoUc3BjLW1zZy1tZXNzYWdlLWd1aWQSEgoQaGVsbG8gZnJvbSBmdXNvclIMCIvb4NIGEICEuNkBogEUCgwrMTU1NTEyMzQ1NjcQARoCVVPaBA5wOisxNTU1MDAwMTExMeIFF2lNZXNzYWdlOy07KzE1NTUxMjM0NTY3",
+    "base64"
+  )
+);
+
+describe("decodeCatchUpEvent", () => {
+  it("decodes and maps a received-message frame", () => {
+    expect(decodeCatchUpEvent(FUSOR_RECEIVED_FRAME)).toMatchObject({
+      actor: {
+        address: "+15551234567",
+        country: "US",
+        service: "iMessage",
+      },
+      chatGuid: "iMessage;-;+15551234567",
+      isFromMe: false,
+      message: {
+        chatGuids: ["iMessage;-;+15551234567"],
+        content: {
+          attachments: [],
+          formatting: [],
+          mentions: [],
+          text: "hello from fusor",
+        },
+        dateCreated: RECEIVED_AT,
+        destinationCallerId: "p:+15550001111",
+        guid: "spc-msg-message-guid",
+        isFromMe: false,
+        sender: {
+          address: "+15551234567",
+          country: "US",
+          service: "iMessage",
+        },
+      },
+      occurredAt: RECEIVED_AT,
+      sequence: 42,
+      type: "message.received",
+    });
+  });
+
+  it("maps the terminal catch-up frame", () => {
+    const bytes = CatchUpEventsResponse.encode(
+      CatchUpEventsResponse.create({ complete: { headSequence: 84 } })
+    ).finish();
+
+    expect(decodeCatchUpEvent(bytes)).toEqual({
+      type: "catchup.complete",
+      headSequence: 84,
+    });
+  });
+
+  it("returns undefined for a heartbeat frame", () => {
+    const bytes = CatchUpEventsResponse.encode(
+      CatchUpEventsResponse.create({ heartbeat: {} })
+    ).finish();
+
+    expect(decodeCatchUpEvent(bytes)).toBeUndefined();
+  });
+
+  it("returns undefined for a valid frame without an event payload", () => {
+    const bytes = CatchUpEventsResponse.encode(
+      CatchUpEventsResponse.create({ sequence: 42 })
+    ).finish();
+
+    expect(decodeCatchUpEvent(bytes)).toBeUndefined();
+  });
+
+  it("propagates generated protobuf decoder errors", () => {
+    expect(() => decodeCatchUpEvent(Uint8Array.of(0xff))).toThrow();
+  });
+});
 
 describe("EventsResource", () => {
   it("validates catch-up cursor before calling transport", async () => {


### PR DESCRIPTION
## Summary

- expose `decodeCatchUpEvent(bytes)` from the public package entrypoint
- reuse the SDK's canonical CatchUp event mapper instead of duplicating generated protobuf mapping in Spectrum
- cover a fixed protobufjs/Fusor golden, heartbeat, terminal catch-up, empty, and decoder-error frames
- document the payload-less and error-propagation behavior

## Why

This is the decoder prerequisite for [ENG-1979](https://linear.app/photonhq/issue/ENG-1979/route-spectrum-ts-imessage-inbound-messages-through-fusor). The Spectrum iMessage adapter receives transformed `CatchUpEventsResponse` bytes from Fusor and needs to map them through the exact same public event model as the direct gRPC transport.

## Validation

- 136 tests
- `bun run check`
- `bun run lint`
- `bun run build`
- declaration export smoke check
- `git diff --check`

## Rollout

Merge and publish this package before updating Spectrum's frozen dependency lock. The Spectrum PR remains draft until that released version is available.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786812161&installation_id=127326493&pr_number=46&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F46&signature=87fee29783ecad4fcf3f78ebae59a5d89dceaac8d8c59c998980444ab6b37345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API reusing existing mapping logic; no changes to gRPC catch-up streaming behavior.
> 
> **Overview**
> Adds a public **`decodeCatchUpEvent(bytes)`** helper so transport adapters (e.g. Fusor-delivered frames) can turn encoded `CatchUpEventsResponse` protobuf into the same **`CatchUpEvent`** shapes as `events.catchUp()`, without importing generated protobuf types.
> 
> Internal **`mapCatchUpFrame`** now takes a typed **`CatchUpEventsResponse`** instead of an ad-hoc frame shape. Heartbeats and payload-less frames still map to **`undefined`**; decode errors propagate.
> 
> The package entrypoint and README document the API. Unit tests cover a fixed Fusor golden frame, terminal catch-up, heartbeat, empty payload, and invalid bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6b49f4c0ecbd4f72bab7a16f0082baa17f148b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `decodeCatchUpEvent` to convert encoded catch-up frames into the SDK’s public event format.
  * Supports received messages and catch-up completion events, including sequence information.
  * Heartbeat and payload-less frames return no event.
  * Decoding errors are surfaced to callers.

* **Documentation**
  * Updated the README with usage details and decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->