### PR TITLE
fix(ci): write and publish for advanced-imessage-ts package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,16 +7,17 @@ on:
 jobs:
   # NOTE(monorepo): since the core/http/grpc split, the publishable package
   # lives in packages/advanced-imessage (the repo root is a private workspace
-  # manifest). The shared workflow must publish from that directory — it needs
-  # a package-path/working-directory input (or an equivalent change) in
-  # photon-hq/buildspace before the next release.
+  # manifest), so the shared workflow must bump and publish from that
+  # directory via working-directory.
   release:
     uses: photon-hq/buildspace/.github/workflows/typescript-service-release.yaml@main
     permissions:
       contents: write
       pull-requests: read
       id-token: write
+      packages: write
     with:
       service-name: advanced-imessage
       use-oidc: true
+      working-directory: packages/advanced-imessage
     secrets: inherit


### PR DESCRIPTION
The shared typescript-service-release workflow's github-packages-publish job declares 'packages: write', which GitHub validates against the caller's grant at parse time even though the job is gated off.

Also pass working-directory now that buildspace supports it: since the core/http/grpc split the repo root is a private workspace manifest, so bump and publish must run in packages/advanced-imessage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786868098&installation_id=127326493&pr_number=48&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F48&signature=66dd42dcdcbb7da4364c1a437a9f0a637ba59e743fb51a0d9d56c765648c1d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow permission and path changes; no runtime application logic.
> 
> **Overview**
> Updates the **Release** workflow so reusable `typescript-service-release` can publish to GitHub Packages and run bump/publish in the correct monorepo package.
> 
> Adds **`packages: write`** on the caller job because the shared workflow’s publish job requires that permission at workflow parse time, even when gated.
> 
> Passes **`working-directory: packages/advanced-imessage`** now that buildspace supports it, so version bumps and npm publish target the publishable package instead of the private root workspace manifest. The inline monorepo note is adjusted to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ce41d00dca8f7916e00d204f5891211dc12bc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to run from the correct package directory.
  * Enabled permission to publish release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->