### PR TITLE
fix(publish): include README and LICENSE in the npm tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ tests/workerd/dist/
 
 # published-package proto copy (created by prepublishOnly)
 packages/advanced-imessage/proto/
+# published-package README/LICENSE copies (created by prepublishOnly)
+packages/advanced-imessage/README.md
+packages/advanced-imessage/LICENSE

--- a/packages/advanced-imessage/package.json
+++ b/packages/advanced-imessage/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "prepublishOnly": "rm -rf proto && PATH=../../node_modules/.bin:$PATH buf export buf.build/photon-hq/imessage:3a73262f18f2485e868bc708ef35f51a -o proto && bun run --cwd ../.. verify:codegen && bun run build"
+    "prepublishOnly": "rm -rf proto && PATH=../../node_modules/.bin:$PATH buf export buf.build/photon-hq/imessage:3a73262f18f2485e868bc708ef35f51a -o proto && bun run --cwd ../.. verify:codegen && bun run build && cp ../../README.md ../../LICENSE ."
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0"


### PR DESCRIPTION
Publishing moved to packages/advanced-imessage, which has no README.md or LICENSE of its own, so npm shipped the package without either. Copy both from the repo root in prepublishOnly and gitignore the copies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786869489&installation_id=127326493&pr_number=49&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F49&signature=6b27e0e2cd1748507c2df1f74515e0957dadece62f6b5dbca77ec2263c9b6029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing process to include the README and LICENSE files in published package copies.
  * Added ignore rules for generated README and LICENSE files to keep them out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->