### PR TITLE
fix:soften longToNumber overflow to prevent stream teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=18.17"
   },
   "scripts": {
-    "generate": "PATH=./node_modules/.bin:$PATH buf generate",
+    "generate": "PATH=./node_modules/.bin:$PATH buf generate && bun run scripts/soften-int64.mjs",
     "generate:http": "openapi-ts -i gen/openapi/imessage.swagger.json -o packages/http/src/generated/http -c @hey-api/client-fetch",
     "verify:codegen": "bun run generate && bun run generate:http && git diff --exit-code -- gen packages/core/src/generated packages/http/src/generated",
     "build": "bun run generate && bun run --cwd packages/advanced-imessage build",

--- a/packages/core/src/generated/google/protobuf/descriptor.ts
+++ b/packages/core/src/generated/google/protobuf/descriptor.ts
@@ -7235,14 +7235,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/google/protobuf/timestamp.ts
+++ b/packages/core/src/generated/google/protobuf/timestamp.ts
@@ -201,14 +201,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/attachment_types.ts
+++ b/packages/core/src/generated/photon/imessage/v1/attachment_types.ts
@@ -646,14 +646,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/chat_service.ts
+++ b/packages/core/src/generated/photon/imessage/v1/chat_service.ts
@@ -1780,14 +1780,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/event_service.ts
+++ b/packages/core/src/generated/photon/imessage/v1/event_service.ts
@@ -420,14 +420,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/group_service.ts
+++ b/packages/core/src/generated/photon/imessage/v1/group_service.ts
@@ -1588,14 +1588,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/location_types.ts
+++ b/packages/core/src/generated/photon/imessage/v1/location_types.ts
@@ -473,14 +473,7 @@ function fromJsonTimestamp(o: any): Date {
 }
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/message_service.ts
+++ b/packages/core/src/generated/photon/imessage/v1/message_service.ts
@@ -4251,14 +4251,7 @@ function fromJsonTimestamp(o: any): Date {
 }
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/src/generated/photon/imessage/v1/poll_service.ts
+++ b/packages/core/src/generated/photon/imessage/v1/poll_service.ts
@@ -996,14 +996,7 @@ export type DeepPartial<T> = T extends Builtin ? T
   : Partial<T>;
 
 function longToNumber(int64: { toString(): string }): number {
-  const num = globalThis.Number(int64.toString());
-  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
-    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
-  }
-  return num;
+  return globalThis.Number(int64.toString());
 }
 
 function isSet(value: any): boolean {

--- a/packages/core/tests/long-to-number.test.ts
+++ b/packages/core/tests/long-to-number.test.ts
@@ -5,8 +5,8 @@ import { SubscribePollEventsResponse } from "../src/generated/photon/imessage/v1
 // Far past Number.MAX_SAFE_INTEGER (2^53 - 1). ts-proto types these fields as
 // `number`, but the wire format can carry the full signed/unsigned 64-bit
 // range, so the cast is required to construct a regression fixture for #23.
-const OVERSIZED_UINT64 = "18446744073709551615" as unknown as number; // 2^64 - 1 (max uint64)
-const OVERSIZED_INT64 = "9223372036854775807" as unknown as number; // 2^63 - 1 (max int64)
+const OVERSIZED_UINT64 = Number("18446744073709551615"); // 2^64 - 1 (max uint64)
+const OVERSIZED_INT64 = Number("9223372036854775807"); // 2^63 - 1 (max int64)
 
 describe("longToNumber overflow handling (issue #23)", () => {
   it("decodes a top-level oversized uint64 sequence without throwing", () => {

--- a/packages/core/tests/long-to-number.test.ts
+++ b/packages/core/tests/long-to-number.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { Timestamp } from "../src/generated/google/protobuf/timestamp.ts";
+import { SubscribePollEventsResponse } from "../src/generated/photon/imessage/v1/poll_service.ts";
+
+// Far past Number.MAX_SAFE_INTEGER (2^53 - 1). ts-proto types these fields as
+// `number`, but the wire format can carry the full signed/unsigned 64-bit
+// range, so the cast is required to construct a regression fixture for #23.
+const OVERSIZED_UINT64 = "18446744073709551615" as unknown as number; // 2^64 - 1 (max uint64)
+const OVERSIZED_INT64 = "9223372036854775807" as unknown as number; // 2^63 - 1 (max int64)
+
+describe("longToNumber overflow handling (issue #23)", () => {
+  it("decodes a top-level oversized uint64 sequence without throwing", () => {
+    const bytes = SubscribePollEventsResponse.encode(
+      SubscribePollEventsResponse.create({
+        sequence: OVERSIZED_UINT64,
+        pollChanged: {
+          chatGuid: "iMessage;-;+15551234567",
+          pollMessageGuid: "poll-guid",
+          occurredAt: new Date("2026-07-16T00:00:00Z"),
+          isFromMe: false,
+          created: { title: "Lunch?", options: [] },
+        },
+      })
+    ).finish();
+
+    const decoded = SubscribePollEventsResponse.decode(bytes);
+
+    expect(decoded.pollChanged?.created?.title).toBe("Lunch?");
+    expect(typeof decoded.sequence).toBe("number");
+    expect(Number.isFinite(decoded.sequence)).toBe(true);
+  });
+
+  it("decodes a nested Timestamp.seconds oversized past MAX_SAFE_INTEGER without throwing", () => {
+    const bytes = Timestamp.encode(
+      Timestamp.create({ seconds: OVERSIZED_INT64, nanos: 0 })
+    ).finish();
+
+    expect(() => Timestamp.decode(bytes)).not.toThrow();
+
+    const decoded = Timestamp.decode(bytes);
+    expect(typeof decoded.seconds).toBe("number");
+    expect(Number.isFinite(decoded.seconds)).toBe(true);
+  });
+});

--- a/scripts/soften-int64.mjs
+++ b/scripts/soften-int64.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "packages/core/src/generated";
+
+function walk(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(path));
+    } else if (entry.name.endsWith(".ts")) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+const THROWING_BODY = `function longToNumber(int64: { toString(): string }): number {
+  const num = globalThis.Number(int64.toString());
+  if (num > globalThis.Number.MAX_SAFE_INTEGER) {
+    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+  }
+  if (num < globalThis.Number.MIN_SAFE_INTEGER) {
+    throw new globalThis.Error("Value is smaller than Number.MIN_SAFE_INTEGER");
+  }
+  return num;
+}`;
+
+const SOFTENED_BODY = `function longToNumber(int64: { toString(): string }): number {
+  return globalThis.Number(int64.toString());
+}`;
+
+const files = walk(ROOT);
+let patched = 0;
+let alreadySoft = 0;
+
+for (const file of files) {
+  const contents = readFileSync(file, "utf8");
+  if (contents.includes(THROWING_BODY)) {
+    writeFileSync(file, contents.replace(THROWING_BODY, SOFTENED_BODY));
+    patched++;
+  } else if (contents.includes("function longToNumber")) {
+    alreadySoft++;
+  }
+}
+
+if (patched === 0 && alreadySoft === 0) {
+  throw new Error(
+    "soften-int64: found no longToNumber helper under " +
+      ROOT +
+      " — ts-proto's emitted shape may have changed; update THROWING_BODY."
+  );
+}
+
+console.log(
+  `soften-int64: patched ${patched} file(s), ${alreadySoft} already softened`
+);


### PR DESCRIPTION
## Summary

this pr fixes #23 
- Add `scripts/soften-int64.mjs`: post-codegen script, replaces the throwing helper body (identical across all 9 generated files) with a lossy-but-non-throwing version.
- Wire into `generate` so `verify:codegen` stays reproducible in CI.
- No public API change — fields stay typed `number`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787003412&installation_id=127326493&pr_number=50&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F50&signature=8fdcebc594eea5b08de8bb348470f024064a3f2036f7307ee95e30526d504e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of oversized 64-bit values to avoid failures and return finite numeric results.
  * Preserved nested response content when handling large sequence values.

* **Tests**
  * Added regression tests covering overflow behavior for event responses and timestamps.

* **Chores**
  * Updated the generation workflow to adjust tool PATH and automatically apply compatibility “softening” after code generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->