### PR TITLE
fix(grpc): avoid Bun session memory resets

### DIFF
--- a/packages/grpc/src/v1/transport/grpc-client.ts
+++ b/packages/grpc/src/v1/transport/grpc-client.ts
@@ -170,6 +170,13 @@ const KEEPALIVE_PERMIT_WITHOUT_CALLS = 1;
 const KEEPALIVE_MAX_PINGS_WITHOUT_DATA = 0;
 
 /**
+ * Preserve grpc-js's effectively unlimited default within Bun's `u32` storage.
+ * Bun 1.3.14 converts grpc-js's Number.MAX_SAFE_INTEGER default to a 1 MiB
+ * limit; the largest `u32` avoids that conversion failure on Bun and Node.
+ */
+const MAX_SESSION_MEMORY_MB = 4_294_967_295;
+
+/**
  * Create a gRPC channel and all service clients with the configured
  * middleware.
  *
@@ -193,7 +200,7 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
   // Keepalive lets clients detect a half-open connection (failure mode 2 of
   // ENG-1688): a silent gateway drop that sends no RST/GOAWAY would otherwise
   // leave the event `for await` blocked forever. Applied to BOTH channels.
-  // Caller-supplied `channelOptions` win, so liveness stays tunable.
+  // Caller-supplied `channelOptions` win, so SDK defaults stay tunable.
   const channelOptions: ChannelOptions = {
     "grpc.max_receive_message_length": MAX_MESSAGE_BYTES,
     "grpc.max_send_message_length": MAX_MESSAGE_BYTES,
@@ -201,6 +208,7 @@ export function createGrpcClients(options: GrpcClientOptions): GrpcClients {
     "grpc.keepalive_timeout_ms": KEEPALIVE_TIMEOUT_MS,
     "grpc.keepalive_permit_without_calls": KEEPALIVE_PERMIT_WITHOUT_CALLS,
     "grpc.http2.max_pings_without_data": KEEPALIVE_MAX_PINGS_WITHOUT_DATA,
+    "grpc-node.max_session_memory": MAX_SESSION_MEMORY_MB,
     ...options.channelOptions,
   };
 

--- a/packages/grpc/tests/grpc-client.test.ts
+++ b/packages/grpc/tests/grpc-client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { ChatServiceDefinition } from "@photon-ai/aim-core/generated/photon/imessage/v1/chat_service";
+import { createServer } from "nice-grpc";
+import { createGrpcClients } from "../src/v1/transport/grpc-client.ts";
+
+const SetBackgroundServiceDefinition = {
+  name: ChatServiceDefinition.name,
+  fullName: ChatServiceDefinition.fullName,
+  methods: {
+    setBackground: ChatServiceDefinition.methods.setBackground,
+  },
+} as const;
+
+describe("createGrpcClients", () => {
+  it("supports concurrent large unary requests on Bun 1.3.14", async () => {
+    let received = 0;
+    const server = createServer({
+      "grpc.max_receive_message_length": 100 * 1024 * 1024,
+    });
+    server.add(SetBackgroundServiceDefinition, {
+      async setBackground() {
+        received += 1;
+        return {};
+      },
+    });
+
+    const port = await server.listen("127.0.0.1:0");
+    const clients = createGrpcClients({
+      address: `127.0.0.1:${port}`,
+      tls: false,
+    });
+
+    try {
+      const data = new Uint8Array(4 * 1024 * 1024);
+      await Promise.all([
+        clients.chats.setBackground({ chatGuid: "any;-;+1", data }),
+        clients.chats.setBackground({ chatGuid: "any;-;+1", data }),
+      ]);
+
+      expect(received).toBe(2);
+    } finally {
+      clients.channel.close();
+      clients.streamChannel.close();
+      await server.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Set `grpc-node.max_session_memory` to the largest value supported by Bun's `u32` HTTP/2 storage.
- Preserve caller overrides by keeping `channelOptions` after the SDK defaults.
- Add a real gRPC regression test with concurrent large unary requests.

## Why

grpc-js uses `Number.MAX_SAFE_INTEGER` to effectively disable its session-memory limit. Bun 1.3.14 cannot convert that value through its int52 path, reads it as zero, and clamps the HTTP/2 session limit to 1 MiB. Once outbound data accumulates, Bun rejects newly created streams with `RST_STREAM(11)` and grpc-js reports `RESOURCE_EXHAUSTED: Bandwidth exhausted or memory limit exceeded`.

`4_294_967_295` is the largest value Bun's `u32` field can preserve. It restores grpc-js's intended effectively unlimited behavior on Bun while remaining valid on Node.

## Verification

- Regression test repeated 20 times on Bun 1.3.14
- Full package suite: 291 passed, 0 failed
- TypeScript check and Biome lint
- Package build and codegen drift check
- Dist smoke tests, publint, and package type-resolution checks
- Negative control with the old default reproduced the original `RESOURCE_EXHAUSTED` failure

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/advanced-imessage-ts/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787069873&installation_id=127326493&pr_number=51&repository=photon-hq%2Fadvanced-imessage-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fadvanced-imessage-ts%2Fpull%2F51&signature=7995c1224423f2ed684542af1769732490ca30192993378f71ef688b736c2261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

Fix ENG-1981
